### PR TITLE
Performance optimizations and benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,8 @@ env:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: Install additional packages
@@ -14,5 +16,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-      - name: Run benchmarks
-        run: cargo bench
+      - name: Run benchmark comparison
+        uses: boa-dev/criterion-compare-action@v3
+        with:
+          branchName: ${{ github.base_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,4 +20,5 @@ jobs:
         uses: boa-dev/criterion-compare-action@v3
         with:
           branchName: ${{ github.base_ref }}
+          benchName: benchmarks
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,18 @@
+name: Benchmarks
+on:
+  pull_request:
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install additional packages
+        run: sudo apt-get update && sudo apt-get install -y build-essential libgtksourceview-5-dev
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Run benchmarks
+        run: cargo bench

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,9 +16,20 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-      - name: Run benchmark comparison
-        uses: boa-dev/criterion-compare-action@v3
-        with:
-          branchName: ${{ github.base_ref }}
-          benchName: benchmarks
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install critcmp
+        run: cargo install critcmp
+      - name: Benchmark PR branch
+        run: cargo bench --bench benchmarks -- --save-baseline pr
+      - name: Benchmark base branch
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git checkout FETCH_HEAD
+          if cargo bench --bench benchmarks -- --save-baseline base 2>/dev/null; then
+            echo "BASE_HAS_BENCH=true" >> "$GITHUB_ENV"
+          else
+            echo "BASE_HAS_BENCH=false" >> "$GITHUB_ENV"
+            echo "Base branch has no benchmarks — skipping comparison"
+          fi
+      - name: Compare benchmarks
+        if: env.BASE_HAS_BENCH == 'true'
+        run: critcmp base pr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "mergers"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2063,18 +2063,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +196,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -248,6 +287,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +384,12 @@ dependencies = [
  "thiserror",
  "walkdir",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -683,6 +795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +825,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -766,10 +895,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -852,6 +1001,7 @@ version = "0.7.4"
 dependencies = [
  "chrono",
  "clap",
+ "criterion",
  "dircmp",
  "gio",
  "gtk4",
@@ -925,6 +1075,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "pango"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1115,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1079,6 +1263,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1351,6 +1555,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1801,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mergers"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2024"
 description = "A visual diff and merge tool for files and directories"
 license = "GPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,10 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.10"
 tempfile = "3.26"
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ source tests/ui_integration/.venv/bin/activate
 pytest tests/ui_integration/ -v
 ```
 
+**Layer 3 — Benchmarks (Criterion)**
+
+Performance-critical paths are benchmarked with [Criterion](https://bheisler.github.io/criterion.rs/book/) at large-project scale (50k–500k lines). Benchmarks cover Myers diff, chunk navigation, conflict detection, VCS parsing, and merge state operations. Property tests (proptest) verify optimized algorithms match naive reference implementations.
+
+```bash
+cargo bench
+```
+
+Benchmarks run automatically on pull requests via `.github/workflows/bench.yml`.
+
 **CI**
 
 The `.github/workflows/ui-tests.yml` workflow runs the full suite on every push, installing `at-spi2-core` and `xdotool` from the system package manager before invoking `make test-release`.

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::similar_names,
+    clippy::format_push_string,
+    clippy::format_collect
+)]
+
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use mergers::{
     _bench::{self, Side},

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,17 +1,27 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use mergers::_bench::{self, Side};
-use mergers::myers::{self, DiffChunk, DiffTag};
+use mergers::{
+    _bench::{self, Side},
+    myers::{self, DiffChunk, DiffTag},
+};
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 fn make_similar_files(n: usize, changes: usize) -> (String, String) {
     let mut a = String::new();
     let mut b = String::new();
-    let step = if changes > 0 { n / (changes + 1) } else { n + 1 };
+    let step = if changes > 0 {
+        n / (changes + 1)
+    } else {
+        n + 1
+    };
     for i in 0..n {
         if changes > 0 && i % step == step / 2 && i / step < changes {
-            a.push_str(&format!("original line {i} with some typical source code content\n"));
-            b.push_str(&format!("modified line {i} with some changed source code content\n"));
+            a.push_str(&format!(
+                "original line {i} with some typical source code content\n"
+            ));
+            b.push_str(&format!(
+                "modified line {i} with some changed source code content\n"
+            ));
         } else {
             let line = format!("common line {i} with typical source code padding content here\n");
             a.push_str(&line);
@@ -192,13 +202,34 @@ fn bench_conflict_flags(c: &mut Criterion) {
     let (left_50k, right_50k) = make_merge_chunks(50_000);
 
     c.bench_function("conflict_flags/10k_chunks", |b| {
-        b.iter(|| _bench::conflict_flags(black_box(&left_10k), Side::B, black_box(&right_10k), Side::A));
+        b.iter(|| {
+            _bench::conflict_flags(
+                black_box(&left_10k),
+                Side::B,
+                black_box(&right_10k),
+                Side::A,
+            )
+        });
     });
     c.bench_function("conflict_flags/30k_chunks", |b| {
-        b.iter(|| _bench::conflict_flags(black_box(&left_30k), Side::B, black_box(&right_30k), Side::A));
+        b.iter(|| {
+            _bench::conflict_flags(
+                black_box(&left_30k),
+                Side::B,
+                black_box(&right_30k),
+                Side::A,
+            )
+        });
     });
     c.bench_function("conflict_flags/50k_chunks", |b| {
-        b.iter(|| _bench::conflict_flags(black_box(&left_50k), Side::B, black_box(&right_50k), Side::A));
+        b.iter(|| {
+            _bench::conflict_flags(
+                black_box(&left_50k),
+                Side::B,
+                black_box(&right_50k),
+                Side::A,
+            )
+        });
     });
 }
 
@@ -223,10 +254,14 @@ fn bench_merged_gutter_chunks(c: &mut Criterion) {
     let (left_30k, right_30k) = make_merge_chunks(30_000);
 
     c.bench_function("merged_gutter_chunks/10k_chunks", |b| {
-        b.iter(|| _bench::merged_gutter_chunks(black_box(&left_10k), black_box(&right_10k), Side::A));
+        b.iter(|| {
+            _bench::merged_gutter_chunks(black_box(&left_10k), black_box(&right_10k), Side::A)
+        });
     });
     c.bench_function("merged_gutter_chunks/30k_chunks", |b| {
-        b.iter(|| _bench::merged_gutter_chunks(black_box(&left_30k), black_box(&right_30k), Side::A));
+        b.iter(|| {
+            _bench::merged_gutter_chunks(black_box(&left_30k), black_box(&right_30k), Side::A)
+        });
     });
 }
 
@@ -235,21 +270,19 @@ fn bench_merged_gutter_chunks(c: &mut Criterion) {
 fn bench_parse_porcelain(c: &mut Criterion) {
     // Monorepo scale: 50k entries with mixed statuses and renames
     let large: Vec<u8> = (0..50_000)
-        .flat_map(|i| {
-            match i % 7 {
-                0 => format!(" M src/deeply/nested/module/submodule/file_{i}.rs\0").into_bytes(),
-                1 => format!("A  src/new/path/to/file_{i}.rs\0").into_bytes(),
-                2 => format!("?? untracked/path/file_{i}.txt\0").into_bytes(),
-                3 => format!("MM src/partially/staged/file_{i}.rs\0").into_bytes(),
-                4 => format!(" D deleted/old/path/file_{i}.rs\0").into_bytes(),
-                5 => {
-                    let mut v = format!("R  src/renamed/new_{i}.rs\0").into_bytes();
-                    v.extend(format!("src/renamed/old_{i}.rs\0").into_bytes());
-                    v
-                }
-                6 => format!("UU src/conflicting/file_{i}.rs\0").into_bytes(),
-                _ => unreachable!(),
+        .flat_map(|i| match i % 7 {
+            0 => format!(" M src/deeply/nested/module/submodule/file_{i}.rs\0").into_bytes(),
+            1 => format!("A  src/new/path/to/file_{i}.rs\0").into_bytes(),
+            2 => format!("?? untracked/path/file_{i}.txt\0").into_bytes(),
+            3 => format!("MM src/partially/staged/file_{i}.rs\0").into_bytes(),
+            4 => format!(" D deleted/old/path/file_{i}.rs\0").into_bytes(),
+            5 => {
+                let mut v = format!("R  src/renamed/new_{i}.rs\0").into_bytes();
+                v.extend(format!("src/renamed/old_{i}.rs\0").into_bytes());
+                v
             }
+            6 => format!("UU src/conflicting/file_{i}.rs\0").into_bytes(),
+            _ => unreachable!(),
         })
         .collect();
 
@@ -327,10 +360,7 @@ criterion_group!(
     bench_merged_gutter_chunks,
 );
 
-criterion_group!(
-    vcs_benches,
-    bench_parse_porcelain,
-);
+criterion_group!(vcs_benches, bench_parse_porcelain,);
 
 criterion_group!(
     merge_state_benches,

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -281,6 +281,7 @@ fn bench_find_conflict_markers(c: &mut Criterion) {
 
 fn bench_conflict_at_cursor(c: &mut Criterion) {
     let text = make_conflict_text(500_000, 500);
+    let blocks = _bench::find_conflict_blocks(&text);
 
     c.bench_function("conflict_at_cursor/line_1000", |b| {
         b.iter(|| _bench::conflict_at_cursor(black_box(&text), 1_000));
@@ -290,6 +291,15 @@ fn bench_conflict_at_cursor(c: &mut Criterion) {
     });
     c.bench_function("conflict_at_cursor/line_490000", |b| {
         b.iter(|| _bench::conflict_at_cursor(black_box(&text), 490_000));
+    });
+    c.bench_function("conflict_at_cursor_fast/line_1000", |b| {
+        b.iter(|| _bench::conflict_at_cursor_fast(black_box(&blocks), 1_000));
+    });
+    c.bench_function("conflict_at_cursor_fast/line_250000", |b| {
+        b.iter(|| _bench::conflict_at_cursor_fast(black_box(&blocks), 250_000));
+    });
+    c.bench_function("conflict_at_cursor_fast/line_490000", |b| {
+        b.iter(|| _bench::conflict_at_cursor_fast(black_box(&blocks), 490_000));
     });
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,338 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use mergers::_bench::{self, Side};
+use mergers::myers::{self, DiffChunk, DiffTag};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn make_similar_files(n: usize, changes: usize) -> (String, String) {
+    let mut a = String::new();
+    let mut b = String::new();
+    let step = if changes > 0 { n / (changes + 1) } else { n + 1 };
+    for i in 0..n {
+        if changes > 0 && i % step == step / 2 && i / step < changes {
+            a.push_str(&format!("original line {i} with some typical source code content\n"));
+            b.push_str(&format!("modified line {i} with some changed source code content\n"));
+        } else {
+            let line = format!("common line {i} with typical source code padding content here\n");
+            a.push_str(&line);
+            b.push_str(&line);
+        }
+    }
+    (a, b)
+}
+
+/// Generate a chunk list with interleaved Equal and non-Equal chunks.
+/// Produces roughly `n_changes` Replace chunks among `n_total` total chunks.
+fn make_chunks(n_total: usize, n_changes: usize) -> Vec<DiffChunk> {
+    let mut chunks = Vec::new();
+    let mut pos_a = 0;
+    let mut pos_b = 0;
+    let mut changes_placed = 0;
+    let step = if n_changes > 0 {
+        n_total / n_changes
+    } else {
+        n_total + 1
+    };
+    for i in 0..n_total {
+        if step > 0 && i % step == step / 2 && changes_placed < n_changes {
+            let len_a = 3;
+            let len_b = 5;
+            chunks.push(DiffChunk {
+                tag: DiffTag::Replace,
+                start_a: pos_a,
+                end_a: pos_a + len_a,
+                start_b: pos_b,
+                end_b: pos_b + len_b,
+            });
+            pos_a += len_a;
+            pos_b += len_b;
+            changes_placed += 1;
+        } else {
+            let len = 20;
+            chunks.push(DiffChunk {
+                tag: DiffTag::Equal,
+                start_a: pos_a,
+                end_a: pos_a + len,
+                start_b: pos_b,
+                end_b: pos_b + len,
+            });
+            pos_a += len;
+            pos_b += len;
+        }
+    }
+    chunks
+}
+
+/// Build two chunk lists that share a middle pane (simulating 3-way merge).
+fn make_merge_chunks(n_total: usize) -> (Vec<DiffChunk>, Vec<DiffChunk>) {
+    let left = make_chunks(n_total, n_total / 3);
+    let right = make_chunks(n_total, n_total / 4);
+    (left, right)
+}
+
+fn make_conflict_text(n_lines: usize, n_conflicts: usize) -> String {
+    let mut text = String::new();
+    let step = n_lines / (n_conflicts + 1);
+    let mut conflicts_placed = 0;
+    for i in 0..n_lines {
+        if conflicts_placed < n_conflicts && i > 0 && i % step == 0 {
+            text.push_str("<<<<<<< HEAD\n");
+            text.push_str("ours line content here\n");
+            text.push_str("more ours content\n");
+            text.push_str("=======\n");
+            text.push_str("theirs line content here\n");
+            text.push_str("more theirs content\n");
+            text.push_str(">>>>>>> feature-branch\n");
+            conflicts_placed += 1;
+        } else {
+            text.push_str(&format!(
+                "normal source code line {i} with realistic padding\n"
+            ));
+        }
+    }
+    text
+}
+
+// ── Myers diff benchmarks ───────────────────────────────────────────────────
+
+fn bench_diff_lines(c: &mut Criterion) {
+    let (a_50k, b_50k) = make_similar_files(50_000, 500);
+    let (a_200k, b_200k) = make_similar_files(200_000, 2_000);
+    let (a_500k, b_500k) = make_similar_files(500_000, 5_000);
+
+    c.bench_function("diff_lines/50k_lines_500_changes", |b| {
+        b.iter(|| myers::diff_lines(black_box(&a_50k), black_box(&b_50k)));
+    });
+    c.bench_function("diff_lines/200k_lines_2k_changes", |b| {
+        b.iter(|| myers::diff_lines(black_box(&a_200k), black_box(&b_200k)));
+    });
+    c.bench_function("diff_lines/500k_lines_5k_changes", |b| {
+        b.iter(|| myers::diff_lines(black_box(&a_500k), black_box(&b_500k)));
+    });
+}
+
+fn bench_diff_completely_different(c: &mut Criterion) {
+    let a: String = (0..50_000).map(|i| format!("line_a_{i}\n")).collect();
+    let b: String = (0..50_000).map(|i| format!("line_b_{i}\n")).collect();
+
+    c.bench_function("diff_lines/50k_completely_different", |bench| {
+        bench.iter(|| myers::diff_lines(black_box(&a), black_box(&b)));
+    });
+}
+
+fn bench_diff_words(c: &mut Criterion) {
+    // Realistic: a full function signature change
+    let long_a = "    pub fn process_data(input: &[u8], config: &Config, mode: ProcessingMode, output: &mut Vec<u8>) -> Result<usize, ProcessError> {";
+    let long_b = "    pub fn process_data(input: &[u8], settings: &Settings, mode: ProcessingMode, buffer: &mut Vec<u8>) -> Result<usize, DataError> {";
+
+    c.bench_function("diff_words/long_signature", |b| {
+        b.iter(|| myers::diff_words(black_box(long_a), black_box(long_b)));
+    });
+}
+
+fn bench_tokenize(c: &mut Criterion) {
+    // 10k lines of realistic source code
+    let code: String = (0..10_000)
+        .map(|i| format!("    let result_{i} = some_module::process(arg_{i}, &config.field_{i}).unwrap_or_else(|| default_{i}.clone());\n"))
+        .collect();
+
+    c.bench_function("tokenize/10k_lines", |b| {
+        b.iter(|| myers::tokenize(black_box(&code)));
+    });
+}
+
+// ── diff_state benchmarks ───────────────────────────────────────────────────
+
+fn bench_find_next_chunk(c: &mut Criterion) {
+    let chunks_50k = make_chunks(150_000, 50_000);
+    let chunks_100k = make_chunks(300_000, 100_000);
+
+    c.bench_function("find_next_chunk/50k_changes", |b| {
+        b.iter(|| _bench::find_next_chunk(black_box(&chunks_50k), 500_000, 1, Side::A, true));
+    });
+    c.bench_function("find_next_chunk/100k_changes", |b| {
+        b.iter(|| _bench::find_next_chunk(black_box(&chunks_100k), 1_000_000, 1, Side::A, true));
+    });
+}
+
+fn bench_format_chunk_label(c: &mut Criterion) {
+    let chunks_50k = make_chunks(150_000, 50_000);
+    let chunks_100k = make_chunks(300_000, 100_000);
+
+    c.bench_function("format_chunk_label/50k_changes", |b| {
+        b.iter(|| _bench::format_chunk_label(black_box(&chunks_50k), Some(75_000)));
+    });
+    c.bench_function("format_chunk_label/100k_changes", |b| {
+        b.iter(|| _bench::format_chunk_label(black_box(&chunks_100k), Some(150_000)));
+    });
+}
+
+fn bench_compute_chunk_map_rects(c: &mut Criterion) {
+    let chunks_50k = make_chunks(150_000, 50_000);
+    let conflict_flags: Vec<bool> = chunks_50k.iter().map(|c| c.tag != DiffTag::Equal).collect();
+
+    c.bench_function("compute_chunk_map_rects/50k_changes", |b| {
+        b.iter(|| {
+            _bench::compute_chunk_map_rects(
+                black_box(&chunks_50k),
+                3_000_000,
+                800.0,
+                Side::A,
+                &conflict_flags,
+            )
+        });
+    });
+}
+
+// ── Conflict detection benchmarks ───────────────────────────────────────────
+
+fn bench_conflict_flags(c: &mut Criterion) {
+    let (left_10k, right_10k) = make_merge_chunks(10_000);
+    let (left_30k, right_30k) = make_merge_chunks(30_000);
+    let (left_50k, right_50k) = make_merge_chunks(50_000);
+
+    c.bench_function("conflict_flags/10k_chunks", |b| {
+        b.iter(|| _bench::conflict_flags(black_box(&left_10k), Side::B, black_box(&right_10k), Side::A));
+    });
+    c.bench_function("conflict_flags/30k_chunks", |b| {
+        b.iter(|| _bench::conflict_flags(black_box(&left_30k), Side::B, black_box(&right_30k), Side::A));
+    });
+    c.bench_function("conflict_flags/50k_chunks", |b| {
+        b.iter(|| _bench::conflict_flags(black_box(&left_50k), Side::B, black_box(&right_50k), Side::A));
+    });
+}
+
+fn bench_middle_conflict_regions(c: &mut Criterion) {
+    let (left_10k, right_10k) = make_merge_chunks(10_000);
+    let (left_30k, right_30k) = make_merge_chunks(30_000);
+    let (left_50k, right_50k) = make_merge_chunks(50_000);
+
+    c.bench_function("middle_conflict_regions/10k_chunks", |b| {
+        b.iter(|| _bench::middle_conflict_regions(black_box(&left_10k), black_box(&right_10k)));
+    });
+    c.bench_function("middle_conflict_regions/30k_chunks", |b| {
+        b.iter(|| _bench::middle_conflict_regions(black_box(&left_30k), black_box(&right_30k)));
+    });
+    c.bench_function("middle_conflict_regions/50k_chunks", |b| {
+        b.iter(|| _bench::middle_conflict_regions(black_box(&left_50k), black_box(&right_50k)));
+    });
+}
+
+fn bench_merged_gutter_chunks(c: &mut Criterion) {
+    let (left_10k, right_10k) = make_merge_chunks(10_000);
+    let (left_30k, right_30k) = make_merge_chunks(30_000);
+
+    c.bench_function("merged_gutter_chunks/10k_chunks", |b| {
+        b.iter(|| _bench::merged_gutter_chunks(black_box(&left_10k), black_box(&right_10k), Side::A));
+    });
+    c.bench_function("merged_gutter_chunks/30k_chunks", |b| {
+        b.iter(|| _bench::merged_gutter_chunks(black_box(&left_30k), black_box(&right_30k), Side::A));
+    });
+}
+
+// ── VCS parsing benchmarks ──────────────────────────────────────────────────
+
+fn bench_parse_porcelain(c: &mut Criterion) {
+    // Monorepo scale: 50k entries with mixed statuses and renames
+    let large: Vec<u8> = (0..50_000)
+        .flat_map(|i| {
+            match i % 7 {
+                0 => format!(" M src/deeply/nested/module/submodule/file_{i}.rs\0").into_bytes(),
+                1 => format!("A  src/new/path/to/file_{i}.rs\0").into_bytes(),
+                2 => format!("?? untracked/path/file_{i}.txt\0").into_bytes(),
+                3 => format!("MM src/partially/staged/file_{i}.rs\0").into_bytes(),
+                4 => format!(" D deleted/old/path/file_{i}.rs\0").into_bytes(),
+                5 => {
+                    let mut v = format!("R  src/renamed/new_{i}.rs\0").into_bytes();
+                    v.extend(format!("src/renamed/old_{i}.rs\0").into_bytes());
+                    v
+                }
+                6 => format!("UU src/conflicting/file_{i}.rs\0").into_bytes(),
+                _ => unreachable!(),
+            }
+        })
+        .collect();
+
+    c.bench_function("parse_porcelain/50k_mixed_entries", |b| {
+        b.iter(|| mergers::vcs::parse_porcelain_nul(black_box(&large)));
+    });
+}
+
+// ── Merge state benchmarks ──────────────────────────────────────────────────
+
+fn bench_merge_change_indices(c: &mut Criterion) {
+    let (left, right) = make_merge_chunks(50_000);
+    c.bench_function("merge_change_indices/50k_chunks", |b| {
+        b.iter(|| _bench::merge_change_indices(black_box(&left), black_box(&right)));
+    });
+}
+
+fn bench_find_conflict_markers(c: &mut Criterion) {
+    let text_200k = make_conflict_text(200_000, 200);
+    let text_500k = make_conflict_text(500_000, 500);
+
+    c.bench_function("find_conflict_markers/200k_lines", |b| {
+        b.iter(|| _bench::find_conflict_markers_in_text(black_box(&text_200k)));
+    });
+    c.bench_function("find_conflict_markers/500k_lines", |b| {
+        b.iter(|| _bench::find_conflict_markers_in_text(black_box(&text_500k)));
+    });
+}
+
+fn bench_conflict_at_cursor(c: &mut Criterion) {
+    let text = make_conflict_text(500_000, 500);
+
+    c.bench_function("conflict_at_cursor/line_1000", |b| {
+        b.iter(|| _bench::conflict_at_cursor(black_box(&text), 1_000));
+    });
+    c.bench_function("conflict_at_cursor/line_250000", |b| {
+        b.iter(|| _bench::conflict_at_cursor(black_box(&text), 250_000));
+    });
+    c.bench_function("conflict_at_cursor/line_490000", |b| {
+        b.iter(|| _bench::conflict_at_cursor(black_box(&text), 490_000));
+    });
+}
+
+// ── Group & main ────────────────────────────────────────────────────────────
+
+criterion_group!(
+    myers_benches,
+    bench_diff_lines,
+    bench_diff_completely_different,
+    bench_diff_words,
+    bench_tokenize,
+);
+
+criterion_group!(
+    diff_state_benches,
+    bench_find_next_chunk,
+    bench_format_chunk_label,
+    bench_compute_chunk_map_rects,
+);
+
+criterion_group!(
+    conflict_benches,
+    bench_conflict_flags,
+    bench_middle_conflict_regions,
+    bench_merged_gutter_chunks,
+);
+
+criterion_group!(
+    vcs_benches,
+    bench_parse_porcelain,
+);
+
+criterion_group!(
+    merge_state_benches,
+    bench_merge_change_indices,
+    bench_find_conflict_markers,
+    bench_conflict_at_cursor,
+);
+
+criterion_main!(
+    myers_benches,
+    diff_state_benches,
+    conflict_benches,
+    vcs_benches,
+    merge_state_benches,
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,19 @@ pub mod settings;
 pub mod ui;
 pub mod vcs;
 
+/// Re-exports for benchmarks. Not part of the public API.
+#[doc(hidden)]
+pub mod _bench {
+    pub use crate::ui::diff_state::{
+        Side, compute_chunk_map_rects, find_next_chunk, format_chunk_label,
+    };
+    pub use crate::ui::common::editor::conflict_flags;
+    pub use crate::ui::common::gutter::{merged_gutter_chunks, middle_conflict_regions};
+    pub use crate::ui::merge_state::{
+        conflict_at_cursor, find_conflict_markers_in_text, merge_change_indices,
+    };
+}
+
 #[derive(Clone, Debug)]
 pub enum CompareMode {
     Files {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ pub mod _bench {
     pub use crate::ui::common::editor::conflict_flags;
     pub use crate::ui::common::gutter::{merged_gutter_chunks, middle_conflict_regions};
     pub use crate::ui::merge_state::{
-        conflict_at_cursor, find_conflict_markers_in_text, merge_change_indices,
+        conflict_at_cursor, conflict_at_cursor_fast, find_conflict_blocks,
+        find_conflict_markers_in_text, merge_change_indices,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,16 @@ pub mod vcs;
 /// Re-exports for benchmarks. Not part of the public API.
 #[doc(hidden)]
 pub mod _bench {
-    pub use crate::ui::diff_state::{
-        Side, compute_chunk_map_rects, find_next_chunk, format_chunk_label,
-    };
-    pub use crate::ui::common::editor::conflict_flags;
-    pub use crate::ui::common::gutter::{merged_gutter_chunks, middle_conflict_regions};
-    pub use crate::ui::merge_state::{
-        conflict_at_cursor, conflict_at_cursor_fast, find_conflict_blocks,
-        find_conflict_markers_in_text, merge_change_indices,
+    pub use crate::ui::{
+        common::{
+            editor::conflict_flags,
+            gutter::{merged_gutter_chunks, middle_conflict_regions},
+        },
+        diff_state::{Side, compute_chunk_map_rects, find_next_chunk, format_chunk_label},
+        merge_state::{
+            conflict_at_cursor, conflict_at_cursor_fast, find_conflict_blocks,
+            find_conflict_markers_in_text, merge_change_indices,
+        },
     };
 }
 

--- a/src/myers.rs
+++ b/src/myers.rs
@@ -474,19 +474,16 @@ fn build_matching_blocks(
         }
     }
 
-    blocks.reverse();
-
-    // Prepend common prefix block
+    // Push prefix block at end (will be first after reverse)
     if common_prefix > 0 {
-        blocks.insert(
-            0,
-            MatchingBlock {
-                a: 0,
-                b: 0,
-                len: common_prefix,
-            },
-        );
+        blocks.push(MatchingBlock {
+            a: 0,
+            b: 0,
+            len: common_prefix,
+        });
     }
+
+    blocks.reverse();
 
     // Append common suffix block
     if common_suffix > 0 {

--- a/src/ui/common/chunk_map.rs
+++ b/src/ui/common/chunk_map.rs
@@ -66,8 +66,7 @@ pub fn create_chunk_map(
     scroll: &ScrolledWindow,
     chunks: &Rc<RefCell<Vec<DiffChunk>>>,
     side: Side,
-    other_chunks: Option<&Rc<RefCell<Vec<DiffChunk>>>>,
-    other_mid: Option<(Side, Side)>,
+    cached_flags: Rc<RefCell<Vec<bool>>>,
 ) -> DrawingArea {
     let map = DrawingArea::new();
     map.set_content_width(12);
@@ -76,14 +75,7 @@ pub fn create_chunk_map(
         let buf = buf.clone();
         let scroll = scroll.clone();
         let chunks = chunks.clone();
-        let other_chunks = other_chunks.cloned();
         map.set_draw_func(move |area, cr, _w, h| {
-            let flags: Vec<bool> =
-                if let (Some(oc), Some((my_mid, oc_mid))) = (&other_chunks, other_mid) {
-                    conflict_flags(&chunks.borrow(), my_mid, &oc.borrow(), oc_mid)
-                } else {
-                    Vec::new()
-                };
             draw_chunk_map(
                 area,
                 cr,
@@ -92,7 +84,7 @@ pub fn create_chunk_map(
                 &scroll,
                 &chunks.borrow(),
                 side,
-                &flags,
+                &cached_flags.borrow(),
             );
         });
     }

--- a/src/ui/common/editor.rs
+++ b/src/ui/common/editor.rs
@@ -104,6 +104,7 @@ pub fn is_dark_scheme() -> bool {
 }
 
 /// Compute perceived luminance from a CSS hex colour string (e.g. `"#2e3436"`).
+#[must_use]
 pub fn hex_luminance(hex: &str) -> f64 {
     let hex = hex.trim_start_matches('#');
     if hex.len() < 6 {
@@ -161,6 +162,7 @@ pub fn apply_scheme_css(settings: &Settings) {
     });
 }
 
+#[must_use]
 pub fn create_source_buffer(file_path: &Path, settings: &Settings) -> TextBuffer {
     let buf = sourceview5::Buffer::new(None::<&gtk4::TextTagTable>);
     let lang_mgr = sourceview5::LanguageManager::default();
@@ -204,6 +206,7 @@ pub fn remove_diff_tags(buf: &TextBuffer) {
 // Chunk fills use opaque `paragraph_background` TextTags (rendered behind text).
 // Strokes, bands, and fillers use Cairo with alpha (drawn on an overlay).
 
+#[must_use]
 pub fn stroke_insert() -> (f64, f64, f64, f64) {
     if is_dark_scheme() {
         (0.30, 0.65, 0.18, 0.8) // bright green
@@ -211,6 +214,7 @@ pub fn stroke_insert() -> (f64, f64, f64, f64) {
         (0.647, 1.0, 0.298, 0.7) // #a5ff4c
     }
 }
+#[must_use]
 pub fn stroke_replace() -> (f64, f64, f64, f64) {
     if is_dark_scheme() {
         (0.20, 0.50, 0.90, 0.8) // bright blue
@@ -218,6 +222,7 @@ pub fn stroke_replace() -> (f64, f64, f64, f64) {
         (0.396, 0.698, 1.0, 0.7) // #65b2ff
     }
 }
+#[must_use]
 pub fn stroke_conflict() -> (f64, f64, f64, f64) {
     if is_dark_scheme() {
         (0.90, 0.35, 0.30, 0.8) // bright red
@@ -226,6 +231,7 @@ pub fn stroke_conflict() -> (f64, f64, f64, f64) {
     }
 }
 
+#[must_use]
 pub fn band_insert() -> (f64, f64, f64) {
     if is_dark_scheme() {
         (0.30, 0.65, 0.18) // bright green
@@ -233,6 +239,7 @@ pub fn band_insert() -> (f64, f64, f64) {
         (0.647, 1.0, 0.298) // #a5ff4c
     }
 }
+#[must_use]
 pub fn band_replace() -> (f64, f64, f64) {
     if is_dark_scheme() {
         (0.20, 0.50, 0.90) // bright blue
@@ -241,6 +248,7 @@ pub fn band_replace() -> (f64, f64, f64) {
     }
 }
 
+#[must_use]
 pub fn band_conflict() -> (f64, f64, f64) {
     if is_dark_scheme() {
         (0.90, 0.35, 0.30) // bright red
@@ -249,12 +257,15 @@ pub fn band_conflict() -> (f64, f64, f64) {
     }
 }
 
+#[must_use]
 pub fn filler_insert() -> (f64, f64, f64) {
     band_insert()
 }
+#[must_use]
 pub fn filler_replace() -> (f64, f64, f64) {
     band_replace()
 }
+#[must_use]
 pub fn inline_changed() -> &'static str {
     if is_dark_scheme() {
         "#8a8a3c" // visible yellow
@@ -262,6 +273,7 @@ pub fn inline_changed() -> &'static str {
         "#c8c864"
     }
 }
+#[must_use]
 pub fn inline_deleted() -> &'static str {
     if is_dark_scheme() {
         "#8a3c3c" // visible red
@@ -269,6 +281,7 @@ pub fn inline_deleted() -> &'static str {
         "#ff9696"
     }
 }
+#[must_use]
 pub fn inline_inserted() -> &'static str {
     if is_dark_scheme() {
         "#3c8a3c" // visible green
@@ -277,6 +290,7 @@ pub fn inline_inserted() -> &'static str {
     }
 }
 
+#[must_use]
 pub fn search_match_bg() -> &'static str {
     if is_dark_scheme() {
         "#9a7a10"
@@ -284,6 +298,7 @@ pub fn search_match_bg() -> &'static str {
         "#ffe066"
     }
 }
+#[must_use]
 pub fn search_current_bg() -> &'static str {
     if is_dark_scheme() {
         "#b86010"
@@ -294,6 +309,7 @@ pub fn search_current_bg() -> &'static str {
 
 // Opaque chunk background colours used by `paragraph_background` TextTags
 // (drawn behind text by the text view, matching Meld's rendering approach).
+#[must_use]
 pub fn chunk_bg_insert() -> &'static str {
     if is_dark_scheme() {
         "#1e4e0e" // visible dark green
@@ -301,6 +317,7 @@ pub fn chunk_bg_insert() -> &'static str {
         "#b0e080" // saturated green (readable with muted-text schemes)
     }
 }
+#[must_use]
 pub fn chunk_bg_replace() -> &'static str {
     if is_dark_scheme() {
         "#0e2e6e" // visible dark blue
@@ -308,6 +325,7 @@ pub fn chunk_bg_replace() -> &'static str {
         "#a0c8ee" // saturated blue
     }
 }
+#[must_use]
 pub fn chunk_bg_conflict() -> &'static str {
     if is_dark_scheme() {
         "#6e2420" // visible dark red
@@ -360,6 +378,7 @@ pub fn apply_chunk_bg_tags(buf: &TextBuffer, chunks: &[DiffChunk], side: Side) {
 
 /// Apply `paragraph_background` tags for conflict regions on the merge middle pane.
 /// Check whether two line ranges overlap (handling zero-width ranges).
+#[must_use]
 pub fn chunks_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
     if a_start == a_end && b_start == b_end {
         a_start == b_start
@@ -614,6 +633,7 @@ pub fn draw_chunk_backgrounds(
 ///
 /// `my_mid` selects which side of `my_chunks` is the middle pane;
 /// `other_mid` selects which side of `other_chunks` is the middle pane.
+#[must_use]
 pub fn conflict_flags(
     my_chunks: &[DiffChunk],
     my_mid: Side,
@@ -1040,6 +1060,7 @@ pub fn draw_merge_fillers(
     }
 }
 
+#[must_use]
 pub fn get_line_text(buf: &TextBuffer, line: usize) -> String {
     let start = buf
         .iter_at_line(line as i32)

--- a/src/ui/common/editor.rs
+++ b/src/ui/common/editor.rs
@@ -620,6 +620,19 @@ pub fn conflict_flags(
     other_chunks: &[DiffChunk],
     other_mid: Side,
 ) -> Vec<bool> {
+    // Pre-collect non-Equal other-chunks with their mid-pane ranges.
+    // These are already sorted by position since chunks are in order.
+    let others: Vec<(usize, usize)> = other_chunks
+        .iter()
+        .filter(|oc| oc.tag != DiffTag::Equal)
+        .map(|oc| match other_mid {
+            Side::A => (oc.start_a, oc.end_a),
+            Side::B => (oc.start_b, oc.end_b),
+        })
+        .collect();
+
+    // Two-pointer sweep: j only advances forward across all my_chunks → O(n+m).
+    let mut j = 0;
     my_chunks
         .iter()
         .map(|mc| {
@@ -630,16 +643,45 @@ pub fn conflict_flags(
                 Side::A => (mc.start_a, mc.end_a),
                 Side::B => (mc.start_b, mc.end_b),
             };
-            other_chunks.iter().any(|oc| {
-                if oc.tag == DiffTag::Equal {
-                    return false;
+            // Advance j past other-chunks that end entirely before this chunk starts.
+            // For a normal range (os < oe): it's fully before when oe <= ms.
+            // For a zero-width point range (os == oe): it's fully before when os < ms.
+            while j < others.len() {
+                let (os, oe) = others[j];
+                if os == oe {
+                    if os < ms {
+                        j += 1;
+                    } else {
+                        break;
+                    }
+                } else if oe <= ms {
+                    j += 1;
+                } else {
+                    break;
                 }
-                let (os, oe) = match other_mid {
-                    Side::A => (oc.start_a, oc.end_a),
-                    Side::B => (oc.start_b, oc.end_b),
-                };
-                chunks_overlap(ms, me, os, oe)
-            })
+            }
+            // Check all other-chunks starting from j that could still overlap.
+            // Once an other-chunk starts at or beyond our end (with no overlap),
+            // no further chunks can overlap either.
+            for &(os, oe) in &others[j..] {
+                if chunks_overlap(ms, me, os, oe) {
+                    return true;
+                }
+                // If this other-chunk starts at or beyond our end, later ones
+                // are even further away, so stop.
+                if ms == me {
+                    // Point range: no overlap possible once os > ms.
+                    if os > ms {
+                        break;
+                    }
+                } else {
+                    // Normal range: no overlap once os >= me.
+                    if os >= me {
+                        break;
+                    }
+                }
+            }
+            false
         })
         .collect()
 }

--- a/src/ui/common/gutter.rs
+++ b/src/ui/common/gutter.rs
@@ -104,6 +104,7 @@ pub fn draw_gutter(
 ///
 /// Returns a sorted, non-overlapping list of `(start, end)` half-open line
 /// ranges on the middle pane where left and right changes overlap.
+#[must_use]
 pub fn middle_conflict_regions(
     left_chunks: &[DiffChunk],
     right_chunks: &[DiffChunk],
@@ -184,6 +185,7 @@ pub fn middle_conflict_regions(
 /// Conflict detection uses the merged conflict regions on the middle pane so
 /// that side-pane chunks sandwiched between two conflicting chunks (but not
 /// directly overlapping the other side) are also included in the conflict band.
+#[must_use]
 pub fn merged_gutter_chunks(
     my_chunks: &[DiffChunk],
     other_chunks: &[DiffChunk],
@@ -356,6 +358,7 @@ pub fn draw_edge_arrow(
     let _ = cr.fill();
 }
 
+#[must_use]
 pub fn get_lines_text(buf: &TextBuffer, start_line: usize, end_line: usize) -> String {
     if start_line >= end_line {
         return String::new();

--- a/src/ui/common/gutter.rs
+++ b/src/ui/common/gutter.rs
@@ -108,31 +108,69 @@ pub fn middle_conflict_regions(
     left_chunks: &[DiffChunk],
     right_chunks: &[DiffChunk],
 ) -> Vec<(usize, usize)> {
-    let mut regions: Vec<(usize, usize)> = Vec::new();
-    for lc in left_chunks {
-        if lc.tag == DiffTag::Equal {
-            continue;
+    // Pre-collect non-Equal chunks projected onto the middle pane.
+    // Left chunks use (start_b, end_b), right chunks use (start_a, end_a).
+    // Both are already sorted by position since they come from diff output.
+    let lefts: Vec<(usize, usize)> = left_chunks
+        .iter()
+        .filter(|c| c.tag != DiffTag::Equal)
+        .map(|c| (c.start_b, c.end_b))
+        .collect();
+    let rights: Vec<(usize, usize)> = right_chunks
+        .iter()
+        .filter(|c| c.tag != DiffTag::Equal)
+        .map(|c| (c.start_a, c.end_a))
+        .collect();
+
+    let mut merged: Vec<(usize, usize)> = Vec::new();
+
+    // Two-pointer sweep: for each left chunk, find all overlapping right chunks.
+    // `rj` tracks where to start scanning in `rights` for the current left chunk.
+    let mut rj: usize = 0;
+    for &(ls, le) in &lefts {
+        // Advance rj past right chunks that cannot overlap this left chunk.
+        // A right chunk (rs, re) is entirely before (ls, le) when:
+        //   - for non-zero-width right: re <= ls (and not a zero-width touch)
+        //   - for zero-width right at rs: rs < ls
+        // We use chunks_overlap to be precise, but we can safely skip right
+        // chunks whose end is strictly before the left start (for non-zero-width)
+        // or whose position is strictly before the left start (for zero-width).
+        while rj < rights.len() {
+            let (rs, re) = rights[rj];
+            if re < ls || (re == ls && !chunks_overlap(ls, le, rs, re)) {
+                rj += 1;
+            } else {
+                break;
+            }
         }
-        for rc in right_chunks {
-            if rc.tag == DiffTag::Equal {
+
+        // Scan forward from rj collecting all overlapping right chunks.
+        let mut rk = rj;
+        while rk < rights.len() {
+            let (rs, re) = rights[rk];
+            if !chunks_overlap(ls, le, rs, re) {
+                // Since rights are sorted, once we pass the left chunk's end
+                // no further right chunks can overlap.
+                // For non-zero-width left: rs >= le means done.
+                // For zero-width left: rs > ls means done.
+                if (ls < le && rs >= le) || (ls == le && rs > ls) {
+                    break;
+                }
+                rk += 1;
                 continue;
             }
-            if chunks_overlap(lc.start_b, lc.end_b, rc.start_a, rc.end_a) {
-                regions.push((lc.start_b.min(rc.start_a), lc.end_b.max(rc.end_a)));
+            let region_start = ls.min(rs);
+            let region_end = le.max(re);
+            // Merge into the output list.
+            if let Some(last) = merged.last_mut()
+                && region_start <= last.1
+            {
+                last.1 = last.1.max(region_end);
+            } else {
+                merged.push((region_start, region_end));
             }
+            rk += 1;
         }
-    }
-    regions.sort_unstable();
-    // Merge overlapping / adjacent regions.
-    let mut merged: Vec<(usize, usize)> = Vec::new();
-    for (s, e) in regions {
-        if let Some(last) = merged.last_mut()
-            && s <= last.1
-        {
-            last.1 = last.1.max(e);
-            continue;
-        }
-        merged.push((s, e));
     }
     merged
 }

--- a/src/ui/common/mod.rs
+++ b/src/ui/common/mod.rs
@@ -5,10 +5,12 @@ use super::diff_state;
 pub(super) use diff_state::Side;
 
 mod chunk_map;
-mod editor;
+#[doc(hidden)]
+pub mod editor;
 mod file_watcher;
 mod find_bar;
-mod gutter;
+#[doc(hidden)]
+pub mod gutter;
 mod helpers;
 mod navigation;
 mod scroll_sync;

--- a/src/ui/common/tests.rs
+++ b/src/ui/common/tests.rs
@@ -403,6 +403,216 @@ fn all_colour_pairs_differ() {
     IS_DARK_SCHEME.with(|c| c.set(false));
 }
 
+// ── conflict_flags ──────────────────────────────────────────
+
+#[test]
+fn conflict_flags_empty_chunks() {
+    let flags = conflict_flags(&[], Side::B, &[], Side::A);
+    assert!(flags.is_empty());
+}
+
+#[test]
+fn conflict_flags_no_overlap() {
+    let my = vec![DiffChunk {
+        tag: DiffTag::Replace,
+        start_a: 0,
+        end_a: 3,
+        start_b: 0,
+        end_b: 3,
+    }];
+    let other = vec![DiffChunk {
+        tag: DiffTag::Replace,
+        start_a: 10,
+        end_a: 15,
+        start_b: 10,
+        end_b: 15,
+    }];
+    // my mid B = (0,3), other mid A = (10,15) → no overlap → false
+    assert_eq!(conflict_flags(&my, Side::B, &other, Side::A), vec![false]);
+}
+
+#[test]
+fn conflict_flags_with_overlap() {
+    let my = vec![
+        DiffChunk {
+            tag: DiffTag::Equal,
+            start_a: 0,
+            end_a: 5,
+            start_b: 0,
+            end_b: 5,
+        },
+        DiffChunk {
+            tag: DiffTag::Replace,
+            start_a: 5,
+            end_a: 8,
+            start_b: 5,
+            end_b: 10,
+        },
+    ];
+    let other = vec![DiffChunk {
+        tag: DiffTag::Replace,
+        start_a: 7,
+        end_a: 12,
+        start_b: 7,
+        end_b: 12,
+    }];
+    // my[0] Equal → false. my[1] mid B = (5,10), other mid A = (7,12) → overlap → true
+    assert_eq!(
+        conflict_flags(&my, Side::B, &other, Side::A),
+        vec![false, true]
+    );
+}
+
+#[test]
+fn conflict_flags_zero_width_insert() {
+    let my = vec![DiffChunk {
+        tag: DiffTag::Insert,
+        start_a: 5,
+        end_a: 5,
+        start_b: 5,
+        end_b: 8,
+    }];
+    let other = vec![DiffChunk {
+        tag: DiffTag::Replace,
+        start_a: 5,
+        end_a: 7,
+        start_b: 5,
+        end_b: 7,
+    }];
+    // my mid B = (5,8), other mid A = (5,7) → overlap → true
+    assert_eq!(conflict_flags(&my, Side::B, &other, Side::A), vec![true]);
+}
+
+#[test]
+fn conflict_flags_all_equal() {
+    let my = vec![DiffChunk {
+        tag: DiffTag::Equal,
+        start_a: 0,
+        end_a: 10,
+        start_b: 0,
+        end_b: 10,
+    }];
+    let other = vec![DiffChunk {
+        tag: DiffTag::Replace,
+        start_a: 3,
+        end_a: 7,
+        start_b: 3,
+        end_b: 7,
+    }];
+    assert_eq!(conflict_flags(&my, Side::B, &other, Side::A), vec![false]);
+}
+
+mod conflict_flags_proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_tag() -> impl Strategy<Value = DiffTag> {
+        prop_oneof![
+            Just(DiffTag::Equal),
+            Just(DiffTag::Replace),
+            Just(DiffTag::Insert),
+            Just(DiffTag::Delete),
+        ]
+    }
+
+    /// Generate sorted, non-overlapping chunks (monotonically increasing positions).
+    fn arb_sorted_chunks() -> impl Strategy<Value = Vec<DiffChunk>> {
+        prop::collection::vec(
+            (
+                arb_tag(),
+                1..50_usize,
+                1..50_usize,
+                1..50_usize,
+                1..50_usize,
+            ),
+            0..15,
+        )
+        .prop_map(|raw| {
+            let mut pos_a = 0_usize;
+            let mut pos_b = 0_usize;
+            raw.into_iter()
+                .map(|(tag, da, db, la, lb)| {
+                    let start_a = pos_a + da;
+                    let end_a = if tag == DiffTag::Delete || tag == DiffTag::Replace {
+                        start_a + la
+                    } else {
+                        start_a
+                    };
+                    let start_b = pos_b + db;
+                    let end_b = if tag == DiffTag::Insert || tag == DiffTag::Replace {
+                        start_b + lb
+                    } else {
+                        start_b
+                    };
+                    pos_a = end_a;
+                    pos_b = end_b;
+                    DiffChunk {
+                        tag,
+                        start_a,
+                        end_a,
+                        start_b,
+                        end_b,
+                    }
+                })
+                .collect()
+        })
+    }
+
+    /// Naive O(n*m) reference implementation.
+    fn conflict_flags_naive(
+        my_chunks: &[DiffChunk],
+        my_mid: Side,
+        other_chunks: &[DiffChunk],
+        other_mid: Side,
+    ) -> Vec<bool> {
+        let others: Vec<(usize, usize)> = other_chunks
+            .iter()
+            .filter(|oc| oc.tag != DiffTag::Equal)
+            .map(|oc| match other_mid {
+                Side::A => (oc.start_a, oc.end_a),
+                Side::B => (oc.start_b, oc.end_b),
+            })
+            .collect();
+        my_chunks
+            .iter()
+            .map(|mc| {
+                if mc.tag == DiffTag::Equal {
+                    return false;
+                }
+                let (ms, me) = match my_mid {
+                    Side::A => (mc.start_a, mc.end_a),
+                    Side::B => (mc.start_b, mc.end_b),
+                };
+                others
+                    .iter()
+                    .any(|&(os, oe)| chunks_overlap(ms, me, os, oe))
+            })
+            .collect()
+    }
+
+    proptest! {
+        #[test]
+        fn conflict_flags_matches_naive(
+            my_chunks in arb_sorted_chunks(),
+            other_chunks in arb_sorted_chunks(),
+        ) {
+            let result = conflict_flags(&my_chunks, Side::B, &other_chunks, Side::A);
+            let expected = conflict_flags_naive(&my_chunks, Side::B, &other_chunks, Side::A);
+            prop_assert_eq!(result, expected);
+        }
+
+        #[test]
+        fn conflict_flags_side_a_matches_naive(
+            my_chunks in arb_sorted_chunks(),
+            other_chunks in arb_sorted_chunks(),
+        ) {
+            let result = conflict_flags(&my_chunks, Side::A, &other_chunks, Side::B);
+            let expected = conflict_flags_naive(&my_chunks, Side::A, &other_chunks, Side::B);
+            prop_assert_eq!(result, expected);
+        }
+    }
+}
+
 // ── map_key_to_action ──────────────────────────────────────
 
 const TEST_BINDINGS: KeyBindings = KeyBindings {

--- a/src/ui/diff_state.rs
+++ b/src/ui/diff_state.rs
@@ -9,7 +9,7 @@ pub(super) enum GutterHit {
 
 /// A rectangle in the chunk-map sidebar for a non-Equal chunk.
 #[derive(Debug, Clone, PartialEq)]
-pub(super) struct ChunkMapRect {
+pub struct ChunkMapRect {
     pub y_start: f64,
     pub height: f64,
     pub tag: DiffTag,
@@ -18,7 +18,7 @@ pub(super) struct ChunkMapRect {
 
 /// Which side of a diff chunk to use for line comparisons.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum Side {
+pub enum Side {
     A,
     B,
 }
@@ -29,7 +29,7 @@ pub(super) enum Side {
 /// `side` selects whether to compare `start_a` or `start_b`.
 /// When `wrap` is true, wraps around if no match is found in the given direction.
 /// Returns `None` if there are no non-Equal chunks (or no match when `wrap` is false).
-pub(super) fn find_next_chunk(
+pub fn find_next_chunk(
     chunks: &[DiffChunk],
     cursor_line: usize,
     direction: i32,
@@ -76,7 +76,7 @@ pub(super) fn find_next_chunk(
 /// - `"No changes"` if all chunks are Equal.
 /// - `"N changes"` if `current` is `None` or points to an Equal chunk.
 /// - `"Change X of Y"` if `current` is a non-Equal chunk (1-indexed).
-pub(super) fn format_chunk_label(chunks: &[DiffChunk], current: Option<usize>) -> String {
+pub fn format_chunk_label(chunks: &[DiffChunk], current: Option<usize>) -> String {
     let non_equal: Vec<usize> = chunks
         .iter()
         .enumerate()
@@ -214,7 +214,7 @@ pub(super) fn hit_test_gutter_arrow(
 /// otherwise `start_b`/`end_b`. Each rectangle has a minimum height of 2 pixels.
 /// Returns empty if `total_lines == 0` or `map_height <= 0.0`.
 #[must_use]
-pub(super) fn compute_chunk_map_rects(
+pub fn compute_chunk_map_rects(
     chunks: &[DiffChunk],
     total_lines: usize,
     map_height: f64,

--- a/src/ui/diff_state.rs
+++ b/src/ui/diff_state.rs
@@ -36,17 +36,6 @@ pub fn find_next_chunk(
     side: Side,
     wrap: bool,
 ) -> Option<usize> {
-    let non_equal: Vec<usize> = chunks
-        .iter()
-        .enumerate()
-        .filter(|(_, c)| c.tag != DiffTag::Equal)
-        .map(|(i, _)| i)
-        .collect();
-
-    if non_equal.is_empty() {
-        return None;
-    }
-
     let start_line = |i: usize| -> usize {
         if side == Side::A {
             chunks[i].start_a
@@ -55,19 +44,37 @@ pub fn find_next_chunk(
         }
     };
 
-    if direction > 0 {
-        let found = non_equal.iter().find(|&&i| start_line(i) > cursor_line);
-        found
-            .or(if wrap { non_equal.first() } else { None })
-            .copied()
-    } else {
-        let found = non_equal
+    let non_equal_iter = || {
+        chunks
             .iter()
-            .rev()
-            .find(|&&i| start_line(i) < cursor_line);
-        found
-            .or(if wrap { non_equal.last() } else { None })
-            .copied()
+            .enumerate()
+            .filter(|(_, c)| c.tag != DiffTag::Equal)
+            .map(|(i, _)| i)
+    };
+
+    if direction > 0 {
+        let mut first = None;
+        let mut found = None;
+        for i in non_equal_iter() {
+            if first.is_none() {
+                first = Some(i);
+            }
+            if start_line(i) > cursor_line {
+                found = Some(i);
+                break;
+            }
+        }
+        found.or(if wrap { first } else { None })
+    } else {
+        let mut last = None;
+        let mut found = None;
+        for i in non_equal_iter() {
+            if start_line(i) < cursor_line {
+                found = Some(i);
+            }
+            last = Some(i);
+        }
+        found.or(if wrap { last } else { None })
     }
 }
 
@@ -77,26 +84,23 @@ pub fn find_next_chunk(
 /// - `"N changes"` if `current` is `None` or points to an Equal chunk.
 /// - `"Change X of Y"` if `current` is a non-Equal chunk (1-indexed).
 pub fn format_chunk_label(chunks: &[DiffChunk], current: Option<usize>) -> String {
-    let non_equal: Vec<usize> = chunks
-        .iter()
-        .enumerate()
-        .filter(|(_, c)| c.tag != DiffTag::Equal)
-        .map(|(i, _)| i)
-        .collect();
+    let mut total = 0usize;
+    let mut position = None;
+    for (i, c) in chunks.iter().enumerate() {
+        if c.tag != DiffTag::Equal {
+            if current == Some(i) {
+                position = Some(total);
+            }
+            total += 1;
+        }
+    }
 
-    let total = non_equal.len();
     if total == 0 {
         return "No changes".to_string();
     }
 
-    match current {
-        Some(cur) => {
-            if let Some(pos) = non_equal.iter().position(|&i| i == cur) {
-                format!("Change {} of {}", pos + 1, total)
-            } else {
-                format!("{total} {}", if total == 1 { "change" } else { "changes" })
-            }
-        }
+    match position {
+        Some(pos) => format!("Change {} of {}", pos + 1, total),
         None => format!("{total} {}", if total == 1 { "change" } else { "changes" }),
     }
 }

--- a/src/ui/diff_state.rs
+++ b/src/ui/diff_state.rs
@@ -29,6 +29,7 @@ pub enum Side {
 /// `side` selects whether to compare `start_a` or `start_b`.
 /// When `wrap` is true, wraps around if no match is found in the given direction.
 /// Returns `None` if there are no non-Equal chunks (or no match when `wrap` is false).
+#[must_use]
 pub fn find_next_chunk(
     chunks: &[DiffChunk],
     cursor_line: usize,
@@ -83,6 +84,7 @@ pub fn find_next_chunk(
 /// - `"No changes"` if all chunks are Equal.
 /// - `"N changes"` if `current` is `None` or points to an Equal chunk.
 /// - `"Change X of Y"` if `current` is a non-Equal chunk (1-indexed).
+#[must_use]
 pub fn format_chunk_label(chunks: &[DiffChunk], current: Option<usize>) -> String {
     let mut total = 0usize;
     let mut position = None;

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -441,10 +441,11 @@ pub(super) fn build_diff_view(
     });
 
     // ── Chunk maps (overview strips) ─────────────────────────────
+    let empty_flags = Rc::new(RefCell::new(Vec::new()));
     let left_chunk_map =
-        create_chunk_map(&left_buf, &left_pane.scroll, &chunks, Side::A, None, None);
+        create_chunk_map(&left_buf, &left_pane.scroll, &chunks, Side::A, empty_flags.clone());
     let right_chunk_map =
-        create_chunk_map(&right_buf, &right_pane.scroll, &chunks, Side::B, None, None);
+        create_chunk_map(&right_buf, &right_pane.scroll, &chunks, Side::B, empty_flags);
 
     // Redraw chunk maps on scroll
     for scroll in [&left_pane.scroll, &right_pane.scroll] {

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -442,10 +442,20 @@ pub(super) fn build_diff_view(
 
     // ── Chunk maps (overview strips) ─────────────────────────────
     let empty_flags = Rc::new(RefCell::new(Vec::new()));
-    let left_chunk_map =
-        create_chunk_map(&left_buf, &left_pane.scroll, &chunks, Side::A, empty_flags.clone());
-    let right_chunk_map =
-        create_chunk_map(&right_buf, &right_pane.scroll, &chunks, Side::B, empty_flags);
+    let left_chunk_map = create_chunk_map(
+        &left_buf,
+        &left_pane.scroll,
+        &chunks,
+        Side::A,
+        empty_flags.clone(),
+    );
+    let right_chunk_map = create_chunk_map(
+        &right_buf,
+        &right_pane.scroll,
+        &chunks,
+        Side::B,
+        empty_flags,
+    );
 
     // Redraw chunk maps on scroll
     for scroll in [&left_pane.scroll, &right_pane.scroll] {

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -853,18 +853,23 @@ pub(super) fn build_dir_tab(
                     }
                 }
 
-                // Restore expanded state (must iterate after each expand since
-                // expanding a row inserts children and shifts positions)
-                for rel in &expanded {
-                    for i in 0..tm.n_items() {
-                        if let Some(row) = tm.item(i).and_then(|o| o.downcast::<TreeListRow>().ok())
-                            && let Some(obj) = row.item().and_downcast::<StringObject>()
-                            && DirRowInfo::decode(&obj.string()).rel_path == rel.as_str()
-                        {
-                            row.set_expanded(true);
-                            break;
-                        }
+                // Restore expanded state with a single forward scan.
+                // Expanding a row inserts its children right after it, so a
+                // forward scan naturally visits those newly-inserted children
+                // and keeps overall complexity O(n) in visible rows.
+                let expanded_set: HashSet<&str> =
+                    expanded.iter().map(|s| s.as_str()).collect();
+                let mut i = 0;
+                while i < tm.n_items() {
+                    if let Some(row) =
+                        tm.item(i).and_then(|o| o.downcast::<TreeListRow>().ok())
+                        && let Some(obj) = row.item().and_downcast::<StringObject>()
+                        && expanded_set
+                            .contains(DirRowInfo::decode(&obj.string()).rel_path.as_str())
+                    {
+                        row.set_expanded(true);
                     }
+                    i += 1;
                 }
 
                 // Restore selection on both panes

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -857,12 +857,10 @@ pub(super) fn build_dir_tab(
                 // Expanding a row inserts its children right after it, so a
                 // forward scan naturally visits those newly-inserted children
                 // and keeps overall complexity O(n) in visible rows.
-                let expanded_set: HashSet<&str> =
-                    expanded.iter().map(|s| s.as_str()).collect();
+                let expanded_set: HashSet<&str> = expanded.iter().map(|s| s.as_str()).collect();
                 let mut i = 0;
                 while i < tm.n_items() {
-                    if let Some(row) =
-                        tm.item(i).and_then(|o| o.downcast::<TreeListRow>().ok())
+                    if let Some(row) = tm.item(i).and_then(|o| o.downcast::<TreeListRow>().ok())
                         && let Some(obj) = row.item().and_downcast::<StringObject>()
                         && expanded_set
                             .contains(DirRowInfo::decode(&obj.string()).rel_path.as_str())

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -857,7 +857,8 @@ pub(super) fn build_dir_tab(
                 // Expanding a row inserts its children right after it, so a
                 // forward scan naturally visits those newly-inserted children
                 // and keeps overall complexity O(n) in visible rows.
-                let expanded_set: HashSet<&str> = expanded.iter().map(|s| s.as_str()).collect();
+                let expanded_set: HashSet<&str> =
+                    expanded.iter().map(std::string::String::as_str).collect();
                 let mut i = 0;
                 while i < tm.n_items() {
                     if let Some(row) = tm.item(i).and_then(|o| o.downcast::<TreeListRow>().ok())

--- a/src/ui/merge_state.rs
+++ b/src/ui/merge_state.rs
@@ -44,25 +44,53 @@ pub fn find_conflict_markers_in_text(text: &str) -> Vec<usize> {
         .collect()
 }
 
+/// Precompute conflict block ranges: `(open_line, close_line)` pairs (both inclusive).
+///
+/// Scans the text once and returns a sorted `Vec` of `(<<<<<<<` line, `>>>>>>>` line)` pairs.
+pub fn find_conflict_blocks(text: &str) -> Vec<(usize, usize)> {
+    let mut blocks = Vec::new();
+    let mut open: Option<usize> = None;
+    for (i, line) in text.lines().enumerate() {
+        if line.starts_with("<<<<<<<") {
+            open = Some(i);
+        } else if line.starts_with(">>>>>>>") {
+            if let Some(start) = open.take() {
+                blocks.push((start, i));
+            }
+        }
+    }
+    blocks
+}
+
+/// Binary search for which precomputed conflict block contains `cursor_line`.
+///
+/// Returns `Some(open_line)` if `cursor_line` falls within a block (inclusive of
+/// both the `<<<<<<<` and `>>>>>>>` lines), or `None` otherwise.
+pub fn conflict_at_cursor_fast(blocks: &[(usize, usize)], cursor_line: usize) -> Option<usize> {
+    // Find the first block whose open_line > cursor_line; the candidate is one before that.
+    let idx = blocks.partition_point(|&(open, _)| open <= cursor_line);
+    if idx == 0 {
+        return None;
+    }
+    let (open, close) = blocks[idx - 1];
+    if cursor_line <= close {
+        Some(open)
+    } else {
+        None
+    }
+}
+
 /// Find the `<<<<<<<` marker line for the conflict block enclosing `cursor_line`, if any.
 ///
 /// A conflict block spans from a `<<<<<<<` line to a `>>>>>>>` line (inclusive).
 /// Returns the line number of the opening `<<<<<<<` marker, which is the value
 /// stored in `current_conflict`.
+///
+/// For repeated calls on the same text, prefer precomputing blocks with
+/// [`find_conflict_blocks`] and using [`conflict_at_cursor_fast`] directly.
 pub fn conflict_at_cursor(text: &str, cursor_line: usize) -> Option<usize> {
-    let mut open: Option<usize> = None;
-    for (i, line) in text.lines().enumerate() {
-        if line.starts_with("<<<<<<<") {
-            open = Some(i);
-        }
-        if i == cursor_line {
-            return open;
-        }
-        if line.starts_with(">>>>>>>") {
-            open = None;
-        }
-    }
-    None
+    let blocks = find_conflict_blocks(text);
+    conflict_at_cursor_fast(&blocks, cursor_line)
 }
 
 #[cfg(test)]

--- a/src/ui/merge_state.rs
+++ b/src/ui/merge_state.rs
@@ -6,6 +6,7 @@ use crate::myers::{DiffChunk, DiffTag};
 /// In the left diff, A = left file and B = middle file, so `start_b` gives the
 /// middle-file line.  In the right diff, A = middle file and B = right file, so
 /// `start_a` gives the middle-file line.
+#[must_use]
 pub fn merge_change_indices(
     left_chunks: &[DiffChunk],
     right_chunks: &[DiffChunk],
@@ -31,6 +32,7 @@ pub fn merge_change_indices(
 /// Find 0-indexed line numbers of `<<<<<<<` conflict markers in the given text.
 ///
 /// A line is considered a conflict marker only if it *starts with* `<<<<<<<`.
+#[must_use]
 pub fn find_conflict_markers_in_text(text: &str) -> Vec<usize> {
     text.lines()
         .enumerate()
@@ -46,17 +48,18 @@ pub fn find_conflict_markers_in_text(text: &str) -> Vec<usize> {
 
 /// Precompute conflict block ranges: `(open_line, close_line)` pairs (both inclusive).
 ///
-/// Scans the text once and returns a sorted `Vec` of `(<<<<<<<` line, `>>>>>>>` line)` pairs.
+/// Scans the text once and returns a sorted `Vec` of (`<<<<<<<` line, `>>>>>>>` line) pairs.
+#[must_use]
 pub fn find_conflict_blocks(text: &str) -> Vec<(usize, usize)> {
     let mut blocks = Vec::new();
     let mut open: Option<usize> = None;
     for (i, line) in text.lines().enumerate() {
         if line.starts_with("<<<<<<<") {
             open = Some(i);
-        } else if line.starts_with(">>>>>>>") {
-            if let Some(start) = open.take() {
-                blocks.push((start, i));
-            }
+        } else if line.starts_with(">>>>>>>")
+            && let Some(start) = open.take()
+        {
+            blocks.push((start, i));
         }
     }
     blocks
@@ -66,6 +69,7 @@ pub fn find_conflict_blocks(text: &str) -> Vec<(usize, usize)> {
 ///
 /// Returns `Some(open_line)` if `cursor_line` falls within a block (inclusive of
 /// both the `<<<<<<<` and `>>>>>>>` lines), or `None` otherwise.
+#[must_use]
 pub fn conflict_at_cursor_fast(blocks: &[(usize, usize)], cursor_line: usize) -> Option<usize> {
     // Find the first block whose open_line > cursor_line; the candidate is one before that.
     let idx = blocks.partition_point(|&(open, _)| open <= cursor_line);
@@ -88,6 +92,7 @@ pub fn conflict_at_cursor_fast(blocks: &[(usize, usize)], cursor_line: usize) ->
 ///
 /// For repeated calls on the same text, prefer precomputing blocks with
 /// [`find_conflict_blocks`] and using [`conflict_at_cursor_fast`] directly.
+#[must_use]
 pub fn conflict_at_cursor(text: &str, cursor_line: usize) -> Option<usize> {
     let blocks = find_conflict_blocks(text);
     conflict_at_cursor_fast(&blocks, cursor_line)

--- a/src/ui/merge_view.rs
+++ b/src/ui/merge_view.rs
@@ -1164,12 +1164,18 @@ pub(super) fn build_merge_view(
     });
 
     // ── Chunk maps for merge view ────────────────────────────────
-    let left_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(
-        conflict_flags(&left_chunks.borrow(), Side::B, &right_chunks.borrow(), Side::A),
-    ));
-    let right_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(
-        conflict_flags(&right_chunks.borrow(), Side::A, &left_chunks.borrow(), Side::B),
-    ));
+    let left_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(conflict_flags(
+        &left_chunks.borrow(),
+        Side::B,
+        &right_chunks.borrow(),
+        Side::A,
+    )));
+    let right_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(conflict_flags(
+        &right_chunks.borrow(),
+        Side::A,
+        &left_chunks.borrow(),
+        Side::B,
+    )));
     let left_chunk_map = create_chunk_map(
         &left_buf,
         &left_pane.scroll,

--- a/src/ui/merge_view.rs
+++ b/src/ui/merge_view.rs
@@ -1164,21 +1164,25 @@ pub(super) fn build_merge_view(
     });
 
     // ── Chunk maps for merge view ────────────────────────────────
+    let left_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(
+        conflict_flags(&left_chunks.borrow(), Side::B, &right_chunks.borrow(), Side::A),
+    ));
+    let right_map_flags: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(
+        conflict_flags(&right_chunks.borrow(), Side::A, &left_chunks.borrow(), Side::B),
+    ));
     let left_chunk_map = create_chunk_map(
         &left_buf,
         &left_pane.scroll,
         &left_chunks,
         Side::A,
-        Some(&right_chunks),
-        Some((Side::B, Side::A)),
+        left_map_flags.clone(),
     );
     let right_chunk_map = create_chunk_map(
         &right_buf,
         &right_pane.scroll,
         &right_chunks,
         Side::B,
-        Some(&left_chunks),
-        Some((Side::A, Side::B)),
+        right_map_flags.clone(),
     );
 
     // Redraw chunk maps on any scroll change
@@ -1219,6 +1223,8 @@ pub(super) fn build_merge_view(
             let st = settings.clone();
             let lb = left_buf.clone();
             let rb = right_buf.clone();
+            let lmf = left_map_flags.clone();
+            let rmf = right_map_flags.clone();
             move || {
                 let lg = lg.clone();
                 let rg = rg.clone();
@@ -1245,7 +1251,14 @@ pub(super) fn build_merge_view(
                 let st = st.clone();
                 let lb = lb.clone();
                 let rb = rb.clone();
+                let lmf = lmf.clone();
+                let rmf = rmf.clone();
                 move || {
+                    // Recompute cached conflict flags after chunks changed.
+                    *lmf.borrow_mut() =
+                        conflict_flags(&lch.borrow(), Side::B, &rch.borrow(), Side::A);
+                    *rmf.borrow_mut() =
+                        conflict_flags(&rch.borrow(), Side::A, &lch.borrow(), Side::B);
                     lg.queue_draw();
                     rg.queue_draw();
                     lcm.queue_draw();

--- a/src/ui/merge_view.rs
+++ b/src/ui/merge_view.rs
@@ -114,10 +114,31 @@ fn find_conflict_markers(buf: &TextBuffer) -> Vec<usize> {
     super::merge_state::find_conflict_markers_in_text(&text)
 }
 
-/// Find the opening `<<<<<<<` marker line for the conflict block at `cursor_line`.
-fn conflict_at_cursor(buf: &TextBuffer, cursor_line: usize) -> Option<usize> {
+/// Return cached conflict markers, populating lazily from the buffer.
+fn get_markers(cache: &Rc<RefCell<Option<Vec<usize>>>>, buf: &TextBuffer) -> Vec<usize> {
+    let mut c = cache.borrow_mut();
+    if let Some(ref v) = *c {
+        return v.clone();
+    }
+    let v = find_conflict_markers(buf);
+    *c = Some(v.clone());
+    v
+}
+
+/// Return cached conflict blocks, populating lazily from the buffer.
+#[allow(clippy::type_complexity)]
+fn get_blocks(
+    cache: &Rc<RefCell<Option<Vec<(usize, usize)>>>>,
+    buf: &TextBuffer,
+) -> Vec<(usize, usize)> {
+    let mut c = cache.borrow_mut();
+    if let Some(ref v) = *c {
+        return v.clone();
+    }
     let text = buf.text(&buf.start_iter(), &buf.end_iter(), false);
-    super::merge_state::conflict_at_cursor(&text, cursor_line)
+    let v = super::merge_state::find_conflict_blocks(&text);
+    *c = Some(v.clone());
+    v
 }
 
 /// Find the next/prev navigation target on a side pane, treating each conflict
@@ -1058,6 +1079,13 @@ pub(super) fn build_merge_view(
         btn.activate_action("diff.next-chunk", None).ok();
     });
 
+    // Cached conflict data — populated lazily, invalidated on buffer change.
+    // Avoids O(n) re-scans on every cursor move / nav sensitivity check.
+    #[allow(clippy::type_complexity)]
+    let cached_markers: Rc<RefCell<Option<Vec<usize>>>> = Rc::new(RefCell::new(None));
+    #[allow(clippy::type_complexity)]
+    let cached_blocks: Rc<RefCell<Option<Vec<(usize, usize)>>>> = Rc::new(RefCell::new(None));
+
     // Navigate conflict helper — jumps between `<<<<<<<` markers in middle buf,
     // and syncs left/right panes to the corresponding line.
     #[allow(clippy::too_many_arguments)]
@@ -1231,6 +1259,8 @@ pub(super) fn build_merge_view(
             let rb = right_buf.clone();
             let lmf = left_map_flags.clone();
             let rmf = right_map_flags.clone();
+            let cmrk = cached_markers.clone();
+            let cblk = cached_blocks.clone();
             move || {
                 let lg = lg.clone();
                 let rg = rg.clone();
@@ -1259,7 +1289,12 @@ pub(super) fn build_merge_view(
                 let rb = rb.clone();
                 let lmf = lmf.clone();
                 let rmf = rmf.clone();
+                let cmrk = cmrk.clone();
+                let cblk = cblk.clone();
                 move || {
+                    // Invalidate conflict caches — buffer content changed.
+                    *cmrk.borrow_mut() = None;
+                    *cblk.borrow_mut() = None;
                     // Recompute cached conflict flags after chunks changed.
                     *lmf.borrow_mut() =
                         conflict_flags(&lch.borrow(), Side::B, &rch.borrow(), Side::A);
@@ -1576,13 +1611,14 @@ pub(super) fn build_merge_view(
             let mb = middle_buf.clone();
             let st = settings.clone();
             let sens = merge_nav_sensitivity;
-            let csens = conflict_nav_sensitivity;
             let lf = left_pane.filler_overlay.clone();
             let mf = middle_pane.filler_overlay.clone();
             let rf = right_pane.filler_overlay.clone();
             let lg = left_gutter.clone();
             let rg = right_gutter.clone();
             let ng = navigating.clone();
+            let cblk = cached_blocks.clone();
+            let cmrk = cached_markers.clone();
             middle_buf.connect_cursor_position_notify(move |_| {
                 if ng.get() {
                     return;
@@ -1653,11 +1689,39 @@ pub(super) fn build_merge_view(
                     wrap,
                 );
 
-                // Conflict: check if cursor is inside a conflict block
-                let in_conflict = conflict_at_cursor(&mb, cursor_line);
+                // Conflict: check if cursor is inside a conflict block (cached)
+                let blocks = get_blocks(&cblk, &mb);
+                let in_conflict = super::merge_state::conflict_at_cursor_fast(&blocks, cursor_line);
                 ccur.set(in_conflict);
-                update_conflict_label(&clbl, &mb, in_conflict);
-                csens(&pcb, &ncb, &mb, &mtv, wrap);
+                let markers = get_markers(&cmrk, &mb);
+                // Inline update_conflict_label with cached markers
+                let total = markers.len();
+                if total == 0 {
+                    clbl.set_label("No conflicts");
+                } else {
+                    match in_conflict {
+                        Some(cur_line) => {
+                            if let Some(pos) = markers.iter().position(|&l| l == cur_line) {
+                                clbl.set_label(&format!("Conflict {} of {}", pos + 1, total));
+                            } else {
+                                clbl.set_label(&format!("{total} conflicts"));
+                            }
+                        }
+                        None => clbl.set_label(&format!("{total} conflicts")),
+                    }
+                }
+                // Inline conflict_nav_sensitivity with cached markers
+                if markers.is_empty() {
+                    pcb.set_sensitive(false);
+                    ncb.set_sensitive(false);
+                } else if wrap {
+                    pcb.set_sensitive(true);
+                    ncb.set_sensitive(true);
+                } else {
+                    let cl = cursor_line;
+                    pcb.set_sensitive(markers.iter().rev().any(|&l| l < cl));
+                    ncb.set_sensitive(markers.iter().any(|&l| l > cl));
+                }
 
                 if at != prev_at {
                     lf.queue_draw();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -78,12 +78,15 @@ fn primary_key_name() -> &'static str {
     }
 }
 
-mod common;
-mod diff_state;
+#[doc(hidden)]
+pub mod common;
+#[doc(hidden)]
+pub mod diff_state;
 mod diff_view;
 mod dir_window;
 mod file_window;
-mod merge_state;
+#[doc(hidden)]
+pub mod merge_state;
 mod merge_view;
 mod preferences;
 mod vcs_window;


### PR DESCRIPTION
## Summary

- Add criterion benchmarks at large-project scale (50k–500k lines) for myers diff, chunk navigation, conflict detection, VCS parsing, and merge state
- Optimize O(n²) conflict detection and navigation to O(n+m) using two-pointer sweep
- Cache conflict flags, binary-search `conflict_at_cursor`, O(n) tree restore in dir view
- Cache `find_conflict_markers`/`find_conflict_blocks` in merge view cursor handler (avoids 3 redundant O(n) buffer scans per cursor move)
- Add `conflict_flags` proptest verifying optimized two-pointer matches naive O(n*m) reference
- Fix clippy pedantic warnings (`must_use`, `format_collect`, `similar_names`, doc backticks)
- Add benchmark CI workflow (runs on PRs only)

## Benchmarks

Criterion benchmarks cover:
- `diff_lines` — 50k/200k/500k lines with varying change density
- `diff_words` — long function signature changes
- `tokenize` — 10k lines of realistic source code
- `find_next_chunk` — 50k/100k change chunks
- `format_chunk_label` — 50k/100k changes
- `compute_chunk_map_rects` — 50k changes
- `conflict_flags` — 10k/30k/50k chunks
- `middle_conflict_regions` — 10k/30k/50k chunks
- `merged_gutter_chunks` — 10k/30k chunks
- `parse_porcelain` — 50k mixed VCS entries
- `merge_change_indices` — 50k chunks
- `find_conflict_markers` — 200k/500k lines
- `conflict_at_cursor` / `conflict_at_cursor_fast` — 500k lines

## Test plan

- [x] `cargo test --all-targets` — 222 tests pass
- [x] `cargo clippy --all-targets -- -D warnings -W clippy::pedantic` — clean
- [x] `cargo +nightly fmt` — clean
- [x] Proptest: `conflict_flags` matches naive reference for random inputs
- [ ] Manual: open 3-way merge, navigate conflicts, verify labels update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)