### PR TITLE
Add patch file support (unified & context diffs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1040,7 +1040,7 @@ dependencies = [
  "serde",
  "sourceview5",
  "tempfile",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.0.7+spec-1.1.0",
  "walkdir",
 ]
 
@@ -1643,22 +1643,22 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -1672,39 +1672,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "typenum"
@@ -2058,6 +2058,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -2152,18 +2158,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -170,9 +170,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -276,15 +276,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9a95621b043a35e70ea9f6da89e1a471658ee5771258874f000a11f6a9cb89"
+checksum = "fa528049fd8726974a7aa1a6e1421f891e7579bea6cc6d54056ab4d1a1b937e7"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d322515677e4a12e10efe7e758743c3e5faa56940237f19ba6890ba8edbbb76"
+checksum = "3dd48b1b03dce78ab52805ac35cfb69c48af71a03af5723231d8583718738377"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16877c6e619447e0bcb6de326a42a8bd02b36328cfeeda210135425e576efa3d"
+checksum = "039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c"
 dependencies = [
  "bitflags 2.11.0",
  "futures-channel",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.22.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48073e3b228419faa80b9b7f7122759d4ab2f44cd52a065fde7ca08f34c03147"
+checksum = "1eb23a616a3dbc7fc15bbd26f58756ff0b04c8a894df3f0680cd21011db6a642"
 dependencies = [
  "libc",
  "system-deps",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84a7e778764e5c8e67440c616e11a0da21828bbf04490655c4058f6c917af6f"
+checksum = "53c912dfcbd28acace5fc99c40bb9f25e1dcb73efb1f2608327f66a99acdcb62"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfbe080ce408e35a94eded4b9cc7a16fa2ffbaf6f04ab5a35d9c3c73841c88"
+checksum = "d7d54bbc7a9d8b6ffe4f0c95eede15ccfb365c8bf521275abe6bcfb57b18fb8a"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f78f0fe325e541c40f1a7f647d324bdda34cf67fe217c2843fd9c18ae514c9"
+checksum = "87f671029e3f5288fd35e03a6e6b19e1ce643b10a3d261d33d183e453f6c52fe"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f063fc314b4d23aac4316a877159c02e86c1b2ba1f0a13e9aafbbebdce9c0800"
+checksum = "d0786e7e8e0550d0ab2df4d0d90032f22033e07d5ed78b6a1b2e51b05340339e"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1130,9 +1130,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "field-offset"
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa528049fd8726974a7aa1a6e1421f891e7579bea6cc6d54056ab4d1a1b937e7"
+checksum = "fd42fdbbf48612c6e8f47c65fb92d2e8f39c25aecd6af047e83897c1a22d2a4e"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd48b1b03dce78ab52805ac35cfb69c48af71a03af5723231d8583718738377"
+checksum = "9d974ac4f15e67472c3a9728daf612590b4a5762a4b33f0edd298df0b80d043c"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816b6743c46b217aa8fba679095ac6f2162fd53259dc8f186fcdbff9c555db03"
+checksum = "17271ffcd5a3cce62e8dbe18924c0894fe125945c5f484d0820a75c2f21a4421"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f93465ac17e6cb02d16f16572cd3e43a77e736d5ecc461e71b9c9c5c0569c"
+checksum = "02856b71413e175be50eff37fe0aefa53e227054ee3d96196faee8a0823cac80"
 dependencies = [
  "bitflags 2.11.0",
  "futures-channel",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f671029e3f5288fd35e03a6e6b19e1ce643b10a3d261d33d183e453f6c52fe"
+checksum = "25d47a7ca9ec6f50b5ace32eaaf11fe152c9bbc4f780a35e42c9b7fc5b046f9c"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0786e7e8e0550d0ab2df4d0d90032f22033e07d5ed78b6a1b2e51b05340339e"
+checksum = "5a25bd07084651c77bb6e7bce7d4cea8d9f98d210acee473e400a9106bc0ce50"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -904,9 +904,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -957,9 +957,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -993,9 +993,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1040,15 +1040,15 @@ dependencies = [
  "serde",
  "sourceview5",
  "tempfile",
- "toml 1.0.7+spec-1.1.0",
+ "toml",
  "walkdir",
 ]
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d8f224eddef627b896d2f7b05725b3faedbd140e0e8343446f0d34f34238ee"
+checksum = "4804fb6018c6604eac198f0f897320d3696c9af7983cde056f07cef93cac9202"
 dependencies = [
  "gio",
  "glib",
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1571,14 +1571,14 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "version-compare",
 ]
 
@@ -1633,78 +1633,54 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
-version = "1.0.7+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 1.0.1+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
@@ -1793,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1806,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1816,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1829,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1872,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2055,15 +2031,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -2158,18 +2128,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +193,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -364,6 +379,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +409,18 @@ dependencies = [
  "sha2",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1002,6 +1040,7 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "ctrlc",
  "dircmp",
  "gio",
  "gtk4",
@@ -1024,6 +1063,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1061,6 +1112,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,25 +312,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -329,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -865,12 +873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,17 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,9 +942,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1145,6 +1136,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pango"
@@ -1880,6 +1881,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1904,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "mergers"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ gtk4 = { version = "0.11", features = ["v4_14"] }
 gio = { version = "0.22", features = ["v2_66"] }
 chrono = "0.4"
 notify = "8.2"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 sourceview5 = { version = "0.11", features = ["gtk_v4_14"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5", features = ["derive"] }
 sourceview5 = { version = "0.11", features = ["gtk_v4_14"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
+ctrlc = { version = "3.5.2", features = ["termination"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ sourceview5 = { version = "0.11", features = ["gtk_v4_14"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
 ctrlc = { version = "3.5.2", features = ["termination"] }
+tempfile = "3.26"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ clap = { version = "4.6", features = ["derive"] }
 sourceview5 = { version = "0.11", features = ["gtk_v4_14"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "1.0"
-ctrlc = { version = "3.5.2", features = ["termination"] }
-tempfile = "3.26"
+ctrlc = { version = "3.5", features = ["termination"] }
+tempfile = "3.27"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.10"
-tempfile = "3.26"
+tempfile = "3.27"
 
 [[bench]]
 name = "benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mergers"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "A visual diff and merge tool for files and directories"
 license = "GPL-2.0"
@@ -19,7 +19,7 @@ toml = "1.0"
 ctrlc = { version = "3.5.2", features = ["termination"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.10"
 tempfile = "3.26"
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A visual diff and merge tool written in Rust with GTK4, inspired by [Meld](https
 - **Chunk navigation** with keyboard shortcuts (with optional wrap-around)
 - **Synchronized scrolling** — chunk-aware vertical sync keeps corresponding lines aligned
 - **Chunk map** — visual overview strips alongside each pane with viewport indicator
+- **Patch viewing** — open `.patch`/`.diff` files to interactively review and apply changes, with conflict markers for failed hunks
 - **Patch export** (unified diff format)
 - **Refresh** (Ctrl+R / F5) — reload files from disk with unsaved-changes confirmation
 - **Open externally** (Ctrl+Shift+O) — open focused file in system default app
@@ -95,6 +96,12 @@ mergers dir1/ dir2/
 # Three-way merge (left, merged, right)
 mergers local.txt merged.txt remote.txt
 
+# Apply a patch to a file (auto-detected from .patch/.diff extension)
+mergers original.txt changes.patch
+
+# Apply a patch to a directory
+mergers project/ changes.patch
+
 # View uncommitted git changes
 mergers .
 
@@ -133,7 +140,7 @@ git mergetool
 | **Find & Replace**                | Yes                   | Yes                            | Yes                                               | No                                       |
 | **Go to Line**                    | Yes                   | No                             | No                                                | No                                       |
 | **Patch Export**                  | Yes                   | No                             | No                                                | Yes                                      |
-| **Patch Viewing/Applying**        | No                    | No                             | No                                                | Yes                                      |
+| **Patch Viewing/Applying**        | Yes                   | No                             | No                                                | Yes                                      |
 | **Ignore Whitespace**             | Yes                   | Yes                            | No                                                | No                                       |
 | **Ignore Blank Lines**            | Yes                   | Yes                            | No                                                | No                                       |
 | **Text Wrapping Options**         | Yes                   | Yes                            | No                                                | No                                       |

--- a/README.md
+++ b/README.md
@@ -120,32 +120,35 @@ git mergetool
 
 ## Comparison with Similar Tools
 
-| Feature                           | mergers               | [Meld](https://meldmerge.org/) | [Diffuse](https://github.com/MightyCreak/diffuse) |
-| --------------------------------- | --------------------- | ------------------------------ | ------------------------------------------------- |
-| **File Comparison**               | 2-way, 3-way          | 2-way, 3-way                   | N-way (arbitrary)                                 |
-| **Directory Comparison**          | Yes                   | Yes                            | No                                                |
-| **VCS Integration**               | Git                   | Git, Hg, Bzr, CVS, SVN         | Git, Hg, Bzr, CVS, SVN, Darcs, Monotone, RCS      |
-| **Syntax Highlighting**           | Yes (GtkSourceView 5) | Yes (GtkSourceView)            | Yes                                               |
-| **Word-level Diffs**              | Yes                   | Yes                            | No                                                |
-| **Inline Editing**                | Yes                   | Yes                            | Yes                                               |
-| **Manual Line Alignment**         | No                    | No                             | Yes                                               |
-| **Undo/Redo**                     | Yes                   | Yes                            | Unlimited undo                                    |
-| **Find & Replace**                | Yes                   | Yes                            | Yes                                               |
-| **Go to Line**                    | Yes                   | No                             | No                                                |
-| **Patch Export**                  | Yes                   | No                             | No                                                |
-| **Ignore Whitespace**             | Yes                   | Yes                            | No                                                |
-| **Ignore Blank Lines**            | Yes                   | Yes                            | No                                                |
-| **Text Wrapping Options**         | Yes                   | Yes                            | No                                                |
-| **File Monitoring / Auto-reload** | Yes                   | Yes                            | No                                                |
-| **Synchronized Scrolling**        | Yes                   | Yes                            | No                                                |
-| **Chunk Map (minimap)**           | Yes                   | Yes                            | No                                                |
-| **Conflict Marker Detection**     | Yes                   | No                             | No                                                |
-| **Folder Filters**                | Yes                   | Yes                            | N/A                                               |
-| **Git Mergetool Support**         | Yes                   | Yes                            | Yes                                               |
-| **Custom Pane Labels**            | Yes                   | Yes                            | Yes                                               |
-| **Toolkit**                       | GTK4                  | GTK3                           | GTK3                                              |
-| **Language**                      | Rust                  | Python                         | Python                                            |
-| **License**                       | GPL-2.0               | GPL-2.0                        | GPL-2.0                                           |
+| Feature                           | mergers               | [Meld](https://meldmerge.org/) | [Diffuse](https://github.com/MightyCreak/diffuse) | [Kompare](https://apps.kde.org/kompare/) |
+| --------------------------------- | --------------------- | ------------------------------ | ------------------------------------------------- | ---------------------------------------- |
+| **File Comparison**               | 2-way, 3-way          | 2-way, 3-way                   | N-way (arbitrary)                                 | 2-way                                    |
+| **Directory Comparison**          | Yes                   | Yes                            | No                                                | Yes                                      |
+| **VCS Integration**               | Git                   | Git, Hg, Bzr, CVS, SVN         | Git, Hg, Bzr, CVS, SVN, Darcs, Monotone, RCS      | No                                       |
+| **Syntax Highlighting**           | Yes (GtkSourceView 5) | Yes (GtkSourceView)            | Yes                                               | No                                       |
+| **Word-level Diffs**              | Yes                   | Yes                            | No                                                | No                                       |
+| **Inline Editing**                | Yes                   | Yes                            | Yes                                               | No                                       |
+| **Manual Line Alignment**         | No                    | No                             | Yes                                               | No                                       |
+| **Undo/Redo**                     | Yes                   | Yes                            | Unlimited undo                                    | No                                       |
+| **Find & Replace**                | Yes                   | Yes                            | Yes                                               | No                                       |
+| **Go to Line**                    | Yes                   | No                             | No                                                | No                                       |
+| **Patch Export**                  | Yes                   | No                             | No                                                | Yes                                      |
+| **Patch Viewing/Applying**        | No                    | No                             | No                                                | Yes                                      |
+| **Ignore Whitespace**             | Yes                   | Yes                            | No                                                | No                                       |
+| **Ignore Blank Lines**            | Yes                   | Yes                            | No                                                | No                                       |
+| **Text Wrapping Options**         | Yes                   | Yes                            | No                                                | No                                       |
+| **File Monitoring / Auto-reload** | Yes                   | Yes                            | No                                                | No                                       |
+| **Synchronized Scrolling**        | Yes                   | Yes                            | No                                                | No                                       |
+| **Chunk Map (minimap)**           | Yes                   | Yes                            | No                                                | No                                       |
+| **Conflict Marker Detection**     | Yes                   | No                             | No                                                | No                                       |
+| **Diff Statistics**               | No                    | No                             | No                                                | Yes                                      |
+| **Folder Filters**                | Yes                   | Yes                            | N/A                                               | No                                       |
+| **Git Mergetool Support**         | Yes                   | Yes                            | Yes                                               | No                                       |
+| **Custom Pane Labels**            | Yes                   | Yes                            | Yes                                               | No                                       |
+| **Remote File Support**           | Via GVFS              | Via GVFS                       | No                                                | Via KIO                                  |
+| **Toolkit**                       | GTK4                  | GTK3                           | GTK3                                              | Qt (KDE Frameworks)                      |
+| **Language**                      | Rust                  | Python                         | Python                                            | C++                                      |
+| **License**                       | GPL-2.0               | GPL-2.0                        | GPL-2.0                                           | GPL-2.0                                  |
 
 ## Building
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,6 +47,10 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 - [x] ✅ Go to line (Ctrl+L): entry appears; type number + Enter to jump; Escape to dismiss; focus returns to active pane
 - [x] ✅ Blanks toggle: re-diffs ignoring blank lines
 - [x] ✅ Spaces toggle: re-diffs ignoring whitespace
+- [ ] Apply all (⏪ button): copies all non-conflicting chunks right → left
+- [ ] Apply all: single undo operation (one Ctrl+Z reverts everything)
+- [ ] Apply all: skips chunks containing conflict markers (`<<<<<<< original` / `>>>>>>> patch`)
+- [ ] Apply all on binary files: button is disabled
 - [ ] Export patch (Ctrl+Shift+P): save dialog; generates unified diff
 - [x] ✅ Swap panes: swaps content, labels, save paths, dirty state; title updates
 - [x] ✅ Preferences (Ctrl+,): opens Preferences
@@ -153,7 +157,7 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 - [ ] Directory headers above each pane with full path as tooltip
 - [ ] Copy path button next to each header: copies full absolute path to clipboard
 - [ ] Copy path after swap: copies the swapped (current) path, not the original
-- [ ] Status colors: blue (different), orange (left-only), green (right-only), dim italic (missing side)
+- [ ] Status colors: blue (different), orange (left-only), green (right-only), red (conflict), dim italic (missing side)
 
 ### Navigation
 - [x] ✅ Double-click file row: opens diff in new notebook tab
@@ -171,6 +175,10 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 - [ ] Delete (Delete key): trashes selected file with confirmation
 - [x] ✅ Collapse all: collapses every expanded directory row
 - [x] ✅ Expand all: expands every directory row
+- [ ] Apply all non-conflicting (⏪ button): copies all non-conflicting files right → left
+- [ ] Apply all: confirmation dialog shows file count
+- [ ] Apply all: handles modified, new, and deleted files
+- [ ] Apply all: skips conflicting files
 - [ ] Swap panes: rescans, updates headers and window title
 - [ ] Preferences (Ctrl+,)
 
@@ -324,6 +332,50 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 
 ### Security
 - [ ] Paths with `..` components refused
+
+## Patch Viewing / Applying
+
+### CLI
+- [ ] `mergers file.c patch.diff`: opens single-file patch view (original vs patched)
+- [ ] `mergers dir/ patch.diff`: opens multi-file patch view (dir comparison)
+- [ ] `-L` labels applied to patch views
+- [ ] Invalid patch file: error dialog shown
+- [ ] Base path does not exist: error dialog shown
+
+### Single-File Patch
+- [ ] Left pane: original file; Right pane: patched result
+- [ ] Conflict hunks shown with `<<<<<<< original` / `>>>>>>> patch` markers in right pane
+- [ ] Labels show base filename and "filename (patched)" (not temp paths)
+- [ ] Window destroy cleans up temp directory
+
+### Multi-File Patch (Dir View)
+- [ ] Left header shows base directory name (not temp path)
+- [ ] Left header tooltip shows original base path (not temp path)
+- [ ] Right header shows "dirname (patched)"
+- [ ] Right header tooltip shows temp directory path
+- [ ] Conflicted files colored red in tree view
+- [ ] Same-status files filtered out of tree view
+- [ ] Empty directories filtered out of tree view
+- [ ] Double-click file: opens diff tab with resolved paths
+- [ ] Diff tab left pane header/tooltip: shows original file path (resolved through symlink)
+- [ ] Diff tab right pane: shows temp patched file path
+- [ ] Unsaved changes dialog shows original path (not temp path)
+
+### Apply All (Dir Patch View)
+- [ ] ⏪ button: confirmation dialog shows file count
+- [ ] Modified files (Different): copied right → left through symlink, then removed from view
+- [ ] New files (RightOnly): created in original directory, parent dirs created as needed
+- [ ] Deleted files (LeftOnly): removed from original directory
+- [ ] Conflicted files: skipped (not applied)
+- [ ] View reloads after apply; applied files vanish from tree
+- [ ] File watcher suppressed during bulk copy (no spurious reloads)
+- [ ] Errors during apply: error dialog shown with details
+
+### Temp Directory Cleanup
+- [ ] Normal window close: temp dir removed (connect_shutdown)
+- [ ] SIGINT (Ctrl+C): temp dir removed (ctrlc handler)
+- [ ] SIGTERM (kill): temp dir removed (ctrlc handler)
+- [ ] Multiple patch windows: all temp dirs tracked and cleaned up
 
 ## Preferences
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,8 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 - [x] ✅ Single file path: prints error and exits
 - [x] ✅ Non-existent path: prints error and exits
 - [x] ✅ File + directory mix: prints error
+- [x] ✅ File + patch file: opens patch viewing window
+- [x] ✅ Directory + patch file: opens multi-file patch dir comparison
 - [x] ✅ `-L`/`--label` flags: custom pane labels shown for 2-file and 3-file modes
 - [x] ✅ `--version` / `--help`: correct output
 
@@ -336,19 +338,29 @@ Items marked ✅ are covered by automated UI integration tests (`tests/ui_integr
 ## Patch Viewing / Applying
 
 ### CLI
-- [ ] `mergers file.c patch.diff`: opens single-file patch view (original vs patched)
-- [ ] `mergers dir/ patch.diff`: opens multi-file patch view (dir comparison)
+- [x] ✅ `mergers file.c patch.diff`: opens single-file patch view (original vs patched)
+- [x] ✅ `mergers dir/ patch.diff`: opens multi-file patch view (dir comparison)
+- [x] ✅ `.diff` extension auto-detected as patch mode
+- [x] ✅ Ctrl+W closes patch window cleanly
 - [ ] `-L` labels applied to patch views
 - [ ] Invalid patch file: error dialog shown
 - [ ] Base path does not exist: error dialog shown
 
 ### Single-File Patch
-- [ ] Left pane: original file; Right pane: patched result
+- [x] ✅ Window title contains "patch" and base filename
+- [x] ✅ Two text panes shown
+- [x] ✅ Left pane: original file content; Right pane: patched result
+- [x] ✅ Right pane contains inserted lines from patch
+- [x] ✅ Chunk label shows change count
+- [x] ✅ Tab label contains "patch"
 - [ ] Conflict hunks shown with `<<<<<<< original` / `>>>>>>> patch` markers in right pane
 - [ ] Labels show base filename and "filename (patched)" (not temp paths)
 - [ ] Window destroy cleans up temp directory
 
 ### Multi-File Patch (Dir View)
+- [x] ✅ Window opens successfully
+- [x] ✅ Shows patched files (e.g. "different.txt")
+- [x] ✅ Shows subdirectories from the patch
 - [ ] Left header shows base directory name (not temp path)
 - [ ] Left header tooltip shows original base path (not temp path)
 - [ ] Right header shows "dirname (patched)"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,7 +4,9 @@
     clippy::format_collect
 )]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use mergers::{
     _bench::{self, Side},
     myers::{self, DiffChunk, DiffTag},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,11 @@ pub enum CompareMode {
         right: PathBuf,
         labels: Vec<String>,
     },
+    Patch {
+        base: PathBuf,
+        patch: PathBuf,
+        labels: Vec<String>,
+    },
     Vcs {
         dir: PathBuf,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 pub mod myers;
+pub mod patch;
 pub mod settings;
 pub mod ui;
 pub mod vcs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 #![windows_subsystem = "windows"]
 
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::{
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
 use gio::prelude::{ApplicationExt, ApplicationExtManual};
@@ -18,7 +20,6 @@ struct Cli {
     /// Custom labels for panes (one per pane)
     #[arg(short = 'L', long = "label", value_name = "LABEL")]
     labels: Vec<String>,
-
 }
 
 fn is_right_a_patch(path: &Path) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use gio::prelude::ApplicationExtManual;
+use gio::prelude::{ApplicationExt, ApplicationExtManual};
 use gtk4::{Application, glib};
 
 use mergers::{CompareMode, ui, vcs};
@@ -11,7 +11,7 @@ use mergers::{CompareMode, ui, vcs};
 #[derive(Parser)]
 #[command(name = "mergers", version, about = "Visual diff and merge tool")]
 struct Cli {
-    /// Paths to compare (2 files or 2 directories, or 3 files for 3-way merge)
+    /// Paths to compare (2 files, 2 dirs, 3 files for merge, or file/dir + patch)
     paths: Vec<PathBuf>,
 
     /// Custom labels for panes (one per pane)
@@ -128,8 +128,26 @@ fn main() -> glib::ExitCode {
 
     let application = Application::builder().application_id("mergers").build();
 
+    // Clean up patch temp dirs on normal shutdown
+    application.connect_shutdown(|_| {
+        ui::cleanup_patch_temp_dirs();
+    });
+
     ui::build_ui(&application, mode);
 
+    // Set up signal handler *after* GTK init so it doesn't get overridden.
+    // ctrlc handles SIGINT and SIGTERM.
+    ctrlc::set_handler(|| {
+        ui::cleanup_patch_temp_dirs();
+        std::process::exit(1);
+    })
+    .ok();
+
     // Pass empty args so GTK doesn't try to parse our directory args
-    application.run_with_args::<String>(&[])
+    let code = application.run_with_args::<String>(&[]);
+
+    // Final cleanup in case shutdown handler didn't fire
+    ui::cleanup_patch_temp_dirs();
+
+    code
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![windows_subsystem = "windows"]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use gio::prelude::ApplicationExtManual;
@@ -17,6 +17,22 @@ struct Cli {
     /// Custom labels for panes (one per pane)
     #[arg(short = 'L', long = "label", value_name = "LABEL")]
     labels: Vec<String>,
+
+    /// Patch format override (unified or context). Auto-detected if omitted.
+    #[arg(long = "patch-format", value_name = "FORMAT")]
+    patch_format: Option<String>,
+}
+
+fn is_right_a_patch(path: &Path) -> bool {
+    if let Some(ext) = path.extension().and_then(|e| e.to_str())
+        && matches!(ext, "patch" | "diff")
+    {
+        return true;
+    }
+    if let Ok(content) = std::fs::read_to_string(path) {
+        return mergers::patch::is_patch_file(&content);
+    }
+    false
 }
 
 fn main() -> glib::ExitCode {
@@ -45,10 +61,29 @@ fn main() -> glib::ExitCode {
         let right = &cli.paths[1];
 
         if left.is_file() && right.is_file() {
-            CompareMode::Files {
-                left: left.clone(),
-                right: right.clone(),
-                labels: cli.labels.clone(),
+            if cli.patch_format.is_some() || is_right_a_patch(right) {
+                CompareMode::Patch {
+                    base: left.clone(),
+                    patch: right.clone(),
+                    labels: cli.labels.clone(),
+                }
+            } else {
+                CompareMode::Files {
+                    left: left.clone(),
+                    right: right.clone(),
+                    labels: cli.labels.clone(),
+                }
+            }
+        } else if left.is_dir() && right.is_file() {
+            if cli.patch_format.is_some() || is_right_a_patch(right) {
+                CompareMode::Patch {
+                    base: left.clone(),
+                    patch: right.clone(),
+                    labels: cli.labels.clone(),
+                }
+            } else {
+                eprintln!("Error: cannot compare a directory with a file");
+                std::process::exit(1);
             }
         } else if left.is_dir() && right.is_dir() {
             CompareMode::Dirs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![windows_subsystem = "windows"]
 
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
@@ -18,9 +19,6 @@ struct Cli {
     #[arg(short = 'L', long = "label", value_name = "LABEL")]
     labels: Vec<String>,
 
-    /// Patch format override (unified or context). Auto-detected if omitted.
-    #[arg(long = "patch-format", value_name = "FORMAT")]
-    patch_format: Option<String>,
 }
 
 fn is_right_a_patch(path: &Path) -> bool {
@@ -29,8 +27,22 @@ fn is_right_a_patch(path: &Path) -> bool {
     {
         return true;
     }
-    if let Ok(content) = std::fs::read_to_string(path) {
-        return mergers::patch::is_patch_file(&content);
+    // Read only the first 50 lines instead of the entire file
+    if let Ok(file) = std::fs::File::open(path) {
+        let reader = BufReader::new(file);
+        let lines: Vec<String> = reader.lines().take(50).filter_map(Result::ok).collect();
+        let preview: Vec<&str> = lines.iter().map(String::as_str).collect();
+        for (i, line) in preview.iter().enumerate() {
+            if *line == "***************" {
+                return true;
+            }
+            if line.starts_with("--- ")
+                && i + 1 < preview.len()
+                && preview[i + 1].starts_with("+++ ")
+            {
+                return true;
+            }
+        }
     }
     false
 }
@@ -61,7 +73,7 @@ fn main() -> glib::ExitCode {
         let right = &cli.paths[1];
 
         if left.is_file() && right.is_file() {
-            if cli.patch_format.is_some() || is_right_a_patch(right) {
+            if is_right_a_patch(right) {
                 CompareMode::Patch {
                     base: left.clone(),
                     patch: right.clone(),
@@ -75,7 +87,7 @@ fn main() -> glib::ExitCode {
                 }
             }
         } else if left.is_dir() && right.is_file() {
-            if cli.patch_format.is_some() || is_right_a_patch(right) {
+            if is_right_a_patch(right) {
                 CompareMode::Patch {
                     base: left.clone(),
                     patch: right.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use gio::prelude::{ApplicationExt, ApplicationExtManual};
 use gtk4::{Application, glib};
 
-use mergers::{CompareMode, ui, vcs};
+use mergers::{CompareMode, patch, ui, vcs};
 
 #[derive(Parser)]
 #[command(name = "mergers", version, about = "Visual diff and merge tool")]
@@ -32,18 +32,8 @@ fn is_right_a_patch(path: &Path) -> bool {
     if let Ok(file) = std::fs::File::open(path) {
         let reader = BufReader::new(file);
         let lines: Vec<String> = reader.lines().take(50).filter_map(Result::ok).collect();
-        let preview: Vec<&str> = lines.iter().map(String::as_str).collect();
-        for (i, line) in preview.iter().enumerate() {
-            if *line == "***************" {
-                return true;
-            }
-            if line.starts_with("--- ")
-                && i + 1 < preview.len()
-                && preview[i + 1].starts_with("+++ ")
-            {
-                return true;
-            }
-        }
+        let preview = lines.join("\n");
+        return patch::is_patch_file(&preview);
     }
     false
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -827,4 +827,94 @@ fn main() {
     fn detect_empty_not_a_patch() {
         assert!(!is_patch_file(""));
     }
+
+    #[test]
+    fn round_trip_unified_parse_apply() {
+        let original = "line1\nline2\nline3\nline4\nline5";
+        let diff = "\
+--- a/test.txt
++++ b/test.txt
+@@ -1,5 +1,6 @@
+ line1
+-line2
++line2modified
+ line3
+ line4
++line4b
+ line5
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        let result = apply_hunks(original, &patches[0].hunks).unwrap();
+        assert_eq!(result, "line1\nline2modified\nline3\nline4\nline4b\nline5");
+    }
+
+    #[test]
+    fn round_trip_context_parse_apply() {
+        let original = "alpha\nbeta\ngamma\ndelta";
+        let diff = "\
+*** test.txt\t2024-01-01 00:00:00.000000000 +0000
+--- test.txt\t2024-01-02 00:00:00.000000000 +0000
+***************
+*** 1,4 ****
+  alpha
+! beta
+! gamma
+  delta
+--- 1,4 ----
+  alpha
+! BETA
+! GAMMA
+  delta
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        let result = apply_hunks(original, &patches[0].hunks).unwrap();
+        assert_eq!(result, "alpha\nBETA\nGAMMA\ndelta");
+    }
+
+    #[test]
+    fn round_trip_multi_file() {
+        let diff = "\
+--- a/one.txt
++++ b/one.txt
+@@ -1,3 +1,3 @@
+ aaa
+-bbb
++BBB
+ ccc
+--- a/two.txt
++++ b/two.txt
+@@ -1,2 +1,3 @@
+ xxx
++yyy
+ zzz
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 2);
+
+        let result1 = apply_hunks("aaa\nbbb\nccc", &patches[0].hunks).unwrap();
+        assert_eq!(result1, "aaa\nBBB\nccc");
+
+        let result2 = apply_hunks("xxx\nzzz", &patches[1].hunks).unwrap();
+        assert_eq!(result2, "xxx\nyyy\nzzz");
+    }
+
+    #[test]
+    fn round_trip_delete_only() {
+        let original = "keep1\nremove1\nremove2\nkeep2";
+        let diff = "\
+--- a/del.txt
++++ b/del.txt
+@@ -1,4 +1,2 @@
+ keep1
+-remove1
+-remove2
+ keep2
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        let result = apply_hunks(original, &patches[0].hunks).unwrap();
+        assert_eq!(result, "keep1\nkeep2");
+    }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1292,4 +1292,318 @@ fn main() {
         assert_eq!(patches[0].kind, PatchKind::Deleted);
         assert_eq!(patches[0].original_path, "old_file.txt");
     }
+
+    // ── sanitize_patch_path edge cases ───────────────────────────────
+
+    #[test]
+    fn sanitize_bare_dotdot() {
+        assert_eq!(sanitize_patch_path(".."), None);
+    }
+
+    #[test]
+    fn sanitize_allows_hidden_files() {
+        assert_eq!(
+            sanitize_patch_path(".gitignore"),
+            Some(".gitignore")
+        );
+        assert_eq!(
+            sanitize_patch_path("src/.hidden/file.rs"),
+            Some("src/.hidden/file.rs")
+        );
+    }
+
+    #[test]
+    fn sanitize_allows_triple_dot() {
+        assert_eq!(sanitize_patch_path("src/.../foo"), Some("src/.../foo"));
+    }
+
+    #[test]
+    fn sanitize_mixed_separators_with_traversal() {
+        assert_eq!(sanitize_patch_path("src/foo\\..\\..\\bar"), None);
+        assert_eq!(sanitize_patch_path("src\\foo/../../../etc"), None);
+    }
+
+    // ── apply_hunks error cases ──────────────────────────────────────
+
+    #[test]
+    fn apply_hunks_overlapping_error() {
+        let original = "a\nb\nc\nd";
+        let hunks = vec![
+            Hunk {
+                old_start: 1,
+                old_count: 3,
+                new_start: 1,
+                new_count: 3,
+                lines: vec![
+                    HunkLine::Remove("a".to_string()),
+                    HunkLine::Add("A".to_string()),
+                    HunkLine::Context("b".to_string()),
+                    HunkLine::Context("c".to_string()),
+                ],
+            },
+            Hunk {
+                old_start: 2, // overlaps with first hunk
+                old_count: 1,
+                new_start: 2,
+                new_count: 1,
+                lines: vec![
+                    HunkLine::Remove("b".to_string()),
+                    HunkLine::Add("B".to_string()),
+                ],
+            },
+        ];
+        let result = apply_hunks(original, &hunks);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().0.contains("overlapping"));
+    }
+
+    #[test]
+    fn apply_hunks_past_end_of_file() {
+        let original = "a\nb";
+        let hunks = vec![Hunk {
+            old_start: 10,
+            old_count: 1,
+            new_start: 10,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("x".to_string()),
+                HunkLine::Add("y".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn apply_hunks_context_mismatch() {
+        let original = "a\nb\nc";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 2,
+            lines: vec![
+                HunkLine::Context("WRONG".to_string()),
+                HunkLine::Remove("b".to_string()),
+                HunkLine::Add("B".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().0.contains("mismatch"));
+    }
+
+    #[test]
+    fn apply_hunks_delete_everything() {
+        let original = "a\nb\nc";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 0,
+            lines: vec![
+                HunkLine::Remove("a".to_string()),
+                HunkLine::Remove("b".to_string()),
+                HunkLine::Remove("c".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn apply_hunks_at_first_line() {
+        let original = "first\nsecond\nthird";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("first".to_string()),
+                HunkLine::Add("FIRST".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "FIRST\nsecond\nthird");
+    }
+
+    #[test]
+    fn apply_hunks_empty_hunks_list() {
+        let original = "unchanged";
+        let result = apply_hunks(original, &[]).unwrap();
+        assert_eq!(result, "unchanged");
+    }
+
+    // ── best-effort edge cases ───────────────────────────────────────
+
+    #[test]
+    fn best_effort_all_hunks_fail() {
+        let original = "a\nb\nc\n";
+        let hunks = vec![
+            Hunk {
+                old_start: 1,
+                old_count: 1,
+                new_start: 1,
+                new_count: 1,
+                lines: vec![
+                    HunkLine::Remove("WRONG".to_string()),
+                    HunkLine::Add("X".to_string()),
+                ],
+            },
+            Hunk {
+                old_start: 3,
+                old_count: 1,
+                new_start: 3,
+                new_count: 1,
+                lines: vec![
+                    HunkLine::Remove("ALSO_WRONG".to_string()),
+                    HunkLine::Add("Y".to_string()),
+                ],
+            },
+        ];
+        let result = apply_hunks_best_effort(original, &hunks);
+        // Both hunks should produce conflict markers
+        let marker_count = result.matches("<<<<<<< original").count();
+        assert_eq!(marker_count, 2);
+    }
+
+    #[test]
+    fn best_effort_preserves_trailing_newline_on_conflict() {
+        let original = "a\nb\nc\n";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("WRONG".to_string()),
+                HunkLine::Add("B".to_string()),
+            ],
+        }];
+        let result = apply_hunks_best_effort(original, &hunks);
+        assert!(result.ends_with('\n'));
+    }
+
+    // ── parse edge cases ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_unified_with_git_prefix() {
+        let diff = "\
+diff --git a/foo.rs b/foo.rs
+index abc1234..def5678 100644
+--- a/foo.rs
++++ b/foo.rs
+@@ -1,2 +1,2 @@
+-old
++new
+ same
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].original_path, "foo.rs");
+    }
+
+    #[test]
+    fn parse_unified_no_newline_marker() {
+        // `\ No newline at end of file` should be ignored (not treated as hunk line)
+        let diff = "\
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,2 +1,2 @@
+-old
++new
+ last
+\\ No newline at end of file
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].hunks[0].lines.len(), 3);
+    }
+
+    #[test]
+    fn parse_unified_added_file() {
+        let diff = "\
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,2 @@
++hello
++world
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].kind, PatchKind::Added);
+        assert_eq!(patches[0].original_path, "new_file.txt");
+    }
+
+    #[test]
+    fn parse_unified_deleted_file() {
+        let diff = "\
+--- a/old_file.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-goodbye
+-world
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].kind, PatchKind::Deleted);
+        assert_eq!(patches[0].original_path, "old_file.txt");
+    }
+
+    #[test]
+    fn is_patch_file_false_for_lone_dashes() {
+        // --- without +++ on next line should not be detected as patch
+        let content = "--- some heading\nregular text\nmore text\n";
+        assert!(!is_patch_file(content));
+    }
+
+    #[test]
+    fn is_patch_file_at_boundary_line_50() {
+        // Patch signature must appear within first 50 lines
+        let mut content = String::new();
+        for i in 0..48 {
+            content.push_str(&format!("filler line {i}\n"));
+        }
+        content.push_str("--- a/file.txt\n+++ b/file.txt\n");
+        assert!(is_patch_file(&content)); // lines 48-49 (0-indexed), within limit
+
+        let mut content_beyond = String::new();
+        for i in 0..50 {
+            content_beyond.push_str(&format!("filler line {i}\n"));
+        }
+        content_beyond.push_str("--- a/file.txt\n+++ b/file.txt\n");
+        assert!(!is_patch_file(&content_beyond)); // lines 50-51, beyond limit
+    }
+
+    #[test]
+    fn parse_context_multi_hunk() {
+        let diff = "\
+*** file.txt\t2024-01-01
+--- file.txt\t2024-01-02
+***************
+*** 1,3 ****
+  aaa
+! bbb
+  ccc
+--- 1,3 ----
+  aaa
+! BBB
+  ccc
+***************
+*** 8,10 ****
+  xxx
+! yyy
+  zzz
+--- 8,10 ----
+  xxx
+! YYY
+  zzz
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].hunks.len(), 2);
+        assert_eq!(patches[0].hunks[0].old_start, 1);
+        assert_eq!(patches[0].hunks[1].old_start, 8);
+    }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -190,6 +190,11 @@ fn parse_context_range(line: &str) -> Result<(usize, usize), PatchError> {
             .trim()
             .parse::<usize>()
             .map_err(|_| PatchError(format!("invalid context range: {line}")))?;
+        if end < start {
+            return Err(PatchError(format!(
+                "invalid context range (end < start): {line}"
+            )));
+        }
         Ok((start, end - start + 1))
     } else {
         let start = inner

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -369,6 +369,82 @@ fn merge_context_sections(
     Ok(result)
 }
 
+/// Apply a list of hunks to the original file content, producing the patched text.
+///
+/// # Errors
+///
+/// Returns `PatchError` if a hunk references lines beyond the original content or if
+/// context/remove lines don't match the original.
+pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError> {
+    let orig_lines: Vec<&str> = if original.is_empty() {
+        Vec::new()
+    } else {
+        original.lines().collect()
+    };
+    let mut output = Vec::new();
+    // 0-based position in orig_lines
+    let mut pos: usize = 0;
+
+    for hunk in hunks {
+        // old_start is 1-based; convert to 0-based index
+        let hunk_start = if hunk.old_start == 0 {
+            0
+        } else {
+            hunk.old_start - 1
+        };
+
+        if hunk_start < pos {
+            return Err(PatchError(format!(
+                "overlapping hunks: expected position >= {}, but hunk starts at {}",
+                pos + 1,
+                hunk.old_start
+            )));
+        }
+
+        // Copy unchanged lines before this hunk
+        for line in &orig_lines[pos..hunk_start] {
+            output.push((*line).to_string());
+        }
+        pos = hunk_start;
+
+        for hl in &hunk.lines {
+            match hl {
+                HunkLine::Context(text) | HunkLine::Remove(text) => {
+                    if pos >= orig_lines.len() {
+                        return Err(PatchError(format!(
+                            "hunk references line {} but original has only {} lines",
+                            pos + 1,
+                            orig_lines.len()
+                        )));
+                    }
+                    if orig_lines[pos] != text.as_str() {
+                        return Err(PatchError(format!(
+                            "mismatch at line {}: expected {:?}, got {:?}",
+                            pos + 1,
+                            text,
+                            orig_lines[pos]
+                        )));
+                    }
+                    if matches!(hl, HunkLine::Context(_)) {
+                        output.push(text.clone());
+                    }
+                    pos += 1;
+                }
+                HunkLine::Add(text) => {
+                    output.push(text.clone());
+                }
+            }
+        }
+    }
+
+    // Copy remaining original lines after the last hunk
+    for line in &orig_lines[pos..] {
+        output.push((*line).to_string());
+    }
+
+    Ok(output.join("\n"))
+}
+
 fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
     let lines: Vec<&str> = input.lines().collect();
     let mut patches = Vec::new();
@@ -590,5 +666,99 @@ mod tests {
         assert!(result.is_err());
         let result = parse_patch("   \n  \n");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn apply_hunks_simple_replace() {
+        let original = "line1\nline2\nline3";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("line2".to_string()),
+                HunkLine::Add("replaced".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nreplaced\nline3");
+    }
+
+    #[test]
+    fn apply_hunks_addition() {
+        let original = "line1\nline2\nline3";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 2,
+            lines: vec![
+                HunkLine::Context("line2".to_string()),
+                HunkLine::Add("inserted".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nline2\ninserted\nline3");
+    }
+
+    #[test]
+    fn apply_hunks_deletion() {
+        let original = "line1\nline2\nline3";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 0,
+            lines: vec![HunkLine::Remove("line2".to_string())],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nline3");
+    }
+
+    #[test]
+    fn apply_hunks_multiple() {
+        let original = "a\nb\nc\nd\ne\nf";
+        let hunks = vec![
+            Hunk {
+                old_start: 2,
+                old_count: 1,
+                new_start: 2,
+                new_count: 1,
+                lines: vec![
+                    HunkLine::Remove("b".to_string()),
+                    HunkLine::Add("B".to_string()),
+                ],
+            },
+            Hunk {
+                old_start: 5,
+                old_count: 1,
+                new_start: 5,
+                new_count: 1,
+                lines: vec![
+                    HunkLine::Remove("e".to_string()),
+                    HunkLine::Add("E".to_string()),
+                ],
+            },
+        ];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "a\nB\nc\nd\nE\nf");
+    }
+
+    #[test]
+    fn apply_hunks_to_empty_original() {
+        let original = "";
+        let hunks = vec![Hunk {
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: 2,
+            lines: vec![
+                HunkLine::Add("new1".to_string()),
+                HunkLine::Add("new2".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "new1\nnew2");
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -88,10 +88,12 @@ fn strip_ab_prefix(path: &str) -> &str {
         .unwrap_or(path)
 }
 
-/// Sanitize a path from a patch file: reject absolute paths and `..` traversal.
+/// Sanitize a path from a patch file: strip leading separators and reject `..` traversal.
 ///
-/// Returns `None` if the path is unsafe (absolute or contains `..` components).
-/// Handles both Unix (`/`, `..`) and Windows (`\`, `C:`) path conventions.
+/// Leading `/` and `\` characters are stripped to make absolute paths relative to the
+/// base directory (similar to `git apply -p0`). Returns `None` if the resulting path
+/// is empty, contains `..` components, or starts with a Windows drive letter.
+/// Handles both Unix and Windows path conventions.
 #[must_use]
 pub fn sanitize_patch_path(path: &str) -> Option<&str> {
     // Strip leading slashes (Unix absolute) and backslashes (Windows absolute)

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1268,12 +1268,18 @@ fn main() {
 
     #[test]
     fn sanitize_normal_path() {
-        assert_eq!(sanitize_patch_path("src/main.rs"), Some("src/main.rs".to_string()));
+        assert_eq!(
+            sanitize_patch_path("src/main.rs"),
+            Some("src/main.rs".to_string())
+        );
     }
 
     #[test]
     fn sanitize_strips_leading_slash() {
-        assert_eq!(sanitize_patch_path("/etc/passwd"), Some("etc/passwd".to_string()));
+        assert_eq!(
+            sanitize_patch_path("/etc/passwd"),
+            Some("etc/passwd".to_string())
+        );
     }
 
     #[test]
@@ -1374,7 +1380,10 @@ fn main() {
 
     #[test]
     fn sanitize_allows_hidden_files() {
-        assert_eq!(sanitize_patch_path(".gitignore"), Some(".gitignore".to_string()));
+        assert_eq!(
+            sanitize_patch_path(".gitignore"),
+            Some(".gitignore".to_string())
+        );
         assert_eq!(
             sanitize_patch_path("src/.hidden/file.rs"),
             Some("src/.hidden/file.rs".to_string())
@@ -1383,7 +1392,10 @@ fn main() {
 
     #[test]
     fn sanitize_allows_triple_dot() {
-        assert_eq!(sanitize_patch_path("src/.../foo"), Some("src/.../foo".to_string()));
+        assert_eq!(
+            sanitize_patch_path("src/.../foo"),
+            Some("src/.../foo".to_string())
+        );
     }
 
     #[test]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -770,9 +770,6 @@ fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
                         hunk_lines.push(HunkLine::Remove(rest.to_string()));
                     } else if let Some(rest) = line.strip_prefix(' ') {
                         hunk_lines.push(HunkLine::Context(rest.to_string()));
-                    } else if line.is_empty() {
-                        // Empty line in a hunk is context with empty content.
-                        hunk_lines.push(HunkLine::Context(String::new()));
                     } else {
                         // Unknown line — end of this hunk.
                         break;

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -104,10 +104,7 @@ pub fn sanitize_patch_path(path: &str) -> Option<&str> {
         return None;
     }
     // Reject `..` as a component with either separator
-    if path
-        .split(['/', '\\'])
-        .any(|c| c == "..")
-    {
+    if path.split(['/', '\\']).any(|c| c == "..") {
         return None;
     }
     Some(path)
@@ -1302,10 +1299,7 @@ fn main() {
 
     #[test]
     fn sanitize_allows_hidden_files() {
-        assert_eq!(
-            sanitize_patch_path(".gitignore"),
-            Some(".gitignore")
-        );
+        assert_eq!(sanitize_patch_path(".gitignore"), Some(".gitignore"));
         assert_eq!(
             sanitize_patch_path("src/.hidden/file.rs"),
             Some("src/.hidden/file.rs")
@@ -1563,14 +1557,16 @@ index abc1234..def5678 100644
         // Patch signature must appear within first 50 lines
         let mut content = String::new();
         for i in 0..48 {
-            content.push_str(&format!("filler line {i}\n"));
+            use std::fmt::Write;
+            let _ = writeln!(content, "filler line {i}");
         }
         content.push_str("--- a/file.txt\n+++ b/file.txt\n");
         assert!(is_patch_file(&content)); // lines 48-49 (0-indexed), within limit
 
         let mut content_beyond = String::new();
         for i in 0..50 {
-            content_beyond.push_str(&format!("filler line {i}\n"));
+            use std::fmt::Write;
+            let _ = writeln!(content_beyond, "filler line {i}");
         }
         content_beyond.push_str("--- a/file.txt\n+++ b/file.txt\n");
         assert!(!is_patch_file(&content_beyond)); // lines 50-51, beyond limit

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,0 +1,281 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct Hunk {
+    pub old_start: usize,
+    pub old_count: usize,
+    pub new_start: usize,
+    pub new_count: usize,
+    pub lines: Vec<HunkLine>,
+}
+
+#[derive(Debug, Clone)]
+pub enum HunkLine {
+    Context(String),
+    Add(String),
+    Remove(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct FilePatch {
+    pub original_path: String,
+    pub hunks: Vec<Hunk>,
+}
+
+#[derive(Debug)]
+pub struct PatchError(pub String);
+
+impl fmt::Display for PatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for PatchError {}
+
+/// Returns true if the input looks like a context diff (not yet supported).
+fn is_context_diff(_input: &str) -> bool {
+    false
+}
+
+/// Parse a unified or context diff into a list of per-file patches.
+///
+/// # Errors
+///
+/// Returns `PatchError` if the input is empty or contains an unsupported diff format.
+pub fn parse_patch(input: &str) -> Result<Vec<FilePatch>, PatchError> {
+    if input.trim().is_empty() {
+        return Err(PatchError("empty patch input".to_string()));
+    }
+
+    if is_context_diff(input) {
+        return Err(PatchError(
+            "context diffs are not yet supported".to_string(),
+        ));
+    }
+
+    parse_unified_diff(input)
+}
+
+/// Strip an optional `a/` or `b/` prefix from a path.
+fn strip_ab_prefix(path: &str) -> &str {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path)
+}
+
+/// Strip a trailing tab-separated timestamp from a path (e.g. `file.txt\t2024-01-01 ...`).
+fn strip_timestamp(path: &str) -> &str {
+    match path.find('\t') {
+        Some(pos) => &path[..pos],
+        None => path,
+    }
+}
+
+/// Parse `@@ -old_start[,old_count] +new_start[,new_count] @@` into `(old_start, old_count,
+/// new_start, new_count)`.
+fn parse_hunk_header(line: &str) -> Result<(usize, usize, usize, usize), PatchError> {
+    let line = line.trim();
+    let rest = line
+        .strip_prefix("@@")
+        .ok_or_else(|| PatchError(format!("invalid hunk header: {line}")))?;
+    // Find the closing @@
+    let rest = match rest.find("@@") {
+        Some(pos) => &rest[..pos],
+        None => return Err(PatchError(format!("invalid hunk header: {line}"))),
+    };
+    let rest = rest.trim();
+
+    let parts: Vec<&str> = rest.split_whitespace().collect();
+    if parts.len() != 2 {
+        return Err(PatchError(format!("invalid hunk header: {line}")));
+    }
+
+    let old = parts[0]
+        .strip_prefix('-')
+        .ok_or_else(|| PatchError(format!("invalid hunk header old range: {line}")))?;
+    let new = parts[1]
+        .strip_prefix('+')
+        .ok_or_else(|| PatchError(format!("invalid hunk header new range: {line}")))?;
+
+    let (old_start, old_count) = parse_range(old, line)?;
+    let (new_start, new_count) = parse_range(new, line)?;
+
+    Ok((old_start, old_count, new_start, new_count))
+}
+
+fn parse_range(range: &str, line: &str) -> Result<(usize, usize), PatchError> {
+    if let Some((start, count)) = range.split_once(',') {
+        let start = start
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid range number in: {line}")))?;
+        let count = count
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid range number in: {line}")))?;
+        Ok((start, count))
+    } else {
+        let start = range
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid range number in: {line}")))?;
+        Ok((start, 1))
+    }
+}
+
+fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut patches = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        // Look for a --- / +++ header pair.
+        if lines[i].starts_with("--- ") && i + 1 < lines.len() && lines[i + 1].starts_with("+++ ") {
+            let old_path = &lines[i][4..];
+            let old_path = strip_timestamp(strip_ab_prefix(old_path.trim()));
+
+            // Skip the +++ line (we use the old path as canonical).
+            i += 2;
+
+            let mut hunks = Vec::new();
+
+            // Parse consecutive hunks.
+            while i < lines.len() && lines[i].starts_with("@@") {
+                let (old_start, old_count, new_start, new_count) = parse_hunk_header(lines[i])?;
+                i += 1;
+
+                let mut hunk_lines = Vec::new();
+
+                while i < lines.len() {
+                    let line = lines[i];
+                    if line.starts_with("--- ") || line.starts_with("@@") {
+                        break;
+                    }
+                    if line.starts_with("\\ ") {
+                        // "\ No newline at end of file" — skip.
+                        i += 1;
+                        continue;
+                    }
+                    if let Some(rest) = line.strip_prefix('+') {
+                        hunk_lines.push(HunkLine::Add(rest.to_string()));
+                    } else if let Some(rest) = line.strip_prefix('-') {
+                        hunk_lines.push(HunkLine::Remove(rest.to_string()));
+                    } else if let Some(rest) = line.strip_prefix(' ') {
+                        hunk_lines.push(HunkLine::Context(rest.to_string()));
+                    } else if line.is_empty() {
+                        // Empty line in a hunk is context with empty content.
+                        hunk_lines.push(HunkLine::Context(String::new()));
+                    } else {
+                        // Unknown line — end of this hunk.
+                        break;
+                    }
+                    i += 1;
+                }
+
+                hunks.push(Hunk {
+                    old_start,
+                    old_count,
+                    new_start,
+                    new_count,
+                    lines: hunk_lines,
+                });
+            }
+
+            patches.push(FilePatch {
+                original_path: old_path.to_string(),
+                hunks,
+            });
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(patches)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_unified_single_file() {
+        let diff = "\
+--- a/hello.txt
++++ b/hello.txt
+@@ -1,3 +1,4 @@
+ line1
+-line2
++line2modified
++line2b
+ line3
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].original_path, "hello.txt");
+        assert_eq!(patches[0].hunks.len(), 1);
+
+        let hunk = &patches[0].hunks[0];
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.old_count, 3);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.new_count, 4);
+        assert_eq!(hunk.lines.len(), 5);
+
+        assert!(matches!(&hunk.lines[0], HunkLine::Context(s) if s == "line1"));
+        assert!(matches!(&hunk.lines[1], HunkLine::Remove(s) if s == "line2"));
+        assert!(matches!(&hunk.lines[2], HunkLine::Add(s) if s == "line2modified"));
+        assert!(matches!(&hunk.lines[3], HunkLine::Add(s) if s == "line2b"));
+        assert!(matches!(&hunk.lines[4], HunkLine::Context(s) if s == "line3"));
+    }
+
+    #[test]
+    fn parse_unified_multi_file() {
+        let diff = "\
+--- a/file1.txt
++++ b/file1.txt
+@@ -1,2 +1,2 @@
+-old
++new
+ same
+--- a/file2.txt
++++ b/file2.txt
+@@ -1 +1 @@
+-alpha
++beta
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 2);
+        assert_eq!(patches[0].original_path, "file1.txt");
+        assert_eq!(patches[1].original_path, "file2.txt");
+        assert_eq!(patches[0].hunks.len(), 1);
+        assert_eq!(patches[1].hunks.len(), 1);
+
+        // Second file: single-number range means count=1.
+        let hunk = &patches[1].hunks[0];
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.old_count, 1);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.new_count, 1);
+    }
+
+    #[test]
+    fn parse_unified_no_prefix() {
+        let diff = "\
+--- hello.txt\t2024-01-01 00:00:00.000000000 +0000
++++ hello.txt\t2024-01-02 00:00:00.000000000 +0000
+@@ -1,2 +1,2 @@
+-aaa
++bbb
+ ccc
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].original_path, "hello.txt");
+    }
+
+    #[test]
+    fn parse_patch_empty_input() {
+        let result = parse_patch("");
+        assert!(result.is_err());
+        let result = parse_patch("   \n  \n");
+        assert!(result.is_err());
+    }
+}

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -38,6 +38,24 @@ fn is_context_diff(input: &str) -> bool {
     input.lines().any(|l| l == "***************")
 }
 
+/// Returns true if the content looks like a patch file (unified or context diff).
+///
+/// Scans the first 50 lines for a unified diff signature (`--- ` immediately followed
+/// by `+++ `) or a context diff separator (`***************`).
+#[must_use]
+pub fn is_patch_file(content: &str) -> bool {
+    let lines: Vec<&str> = content.lines().take(50).collect();
+    for (i, line) in lines.iter().enumerate() {
+        if *line == "***************" {
+            return true;
+        }
+        if line.starts_with("--- ") && i + 1 < lines.len() && lines[i + 1].starts_with("+++ ") {
+            return true;
+        }
+    }
+    false
+}
+
 /// Parse a unified or context diff into a list of per-file patches.
 ///
 /// # Errors
@@ -760,5 +778,53 @@ mod tests {
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "new1\nnew2");
+    }
+
+    #[test]
+    fn detect_unified_patch() {
+        let content = "\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ line1
+-line2
++line2modified
+ line3
+";
+        assert!(is_patch_file(content));
+    }
+
+    #[test]
+    fn detect_context_patch() {
+        let content = "\
+*** file.txt\t2024-01-01 00:00:00.000000000 +0000
+--- file.txt\t2024-01-02 00:00:00.000000000 +0000
+***************
+*** 1,3 ****
+  line1
+! line2
+  line3
+--- 1,3 ----
+  line1
+! line2modified
+  line3
+";
+        assert!(is_patch_file(content));
+    }
+
+    #[test]
+    fn detect_not_a_patch() {
+        let content = "\
+fn main() {
+    println!(\"Hello, world!\");
+}
+";
+        assert!(!is_patch_file(content));
+    }
+
+    #[test]
+    fn detect_empty_not_a_patch() {
+        assert!(!is_patch_file(""));
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -42,8 +42,30 @@ impl fmt::Display for PatchError {
 impl std::error::Error for PatchError {}
 
 /// Returns true if the input looks like a context diff.
+///
+/// Requires both a `***************` separator and a file header pair
+/// (`*** <path>` followed by `--- <path>`) to avoid mis-detecting unified
+/// diffs or non-diff text that happen to contain that separator line.
 fn is_context_diff(input: &str) -> bool {
-    input.lines().any(|l| l == "***************")
+    let mut has_separator = false;
+    let mut has_header = false;
+    let lines: Vec<&str> = input.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if *line == "***************" {
+            has_separator = true;
+        }
+        if line.starts_with("*** ")
+            && !line.contains("****")
+            && i + 1 < lines.len()
+            && lines[i + 1].starts_with("--- ")
+        {
+            has_header = true;
+        }
+        if has_separator && has_header {
+            return true;
+        }
+    }
+    false
 }
 
 /// Returns true if the content looks like a patch file (unified or context diff).
@@ -53,15 +75,26 @@ fn is_context_diff(input: &str) -> bool {
 #[must_use]
 pub fn is_patch_file(content: &str) -> bool {
     let lines: Vec<&str> = content.lines().take(50).collect();
+    let mut has_ctx_sep = false;
+    let mut has_ctx_header = false;
     for (i, line) in lines.iter().enumerate() {
-        if *line == "***************" {
-            return true;
-        }
+        // Unified: --- immediately followed by +++
         if line.starts_with("--- ") && i + 1 < lines.len() && lines[i + 1].starts_with("+++ ") {
             return true;
         }
+        // Context: require both separator and file header pair
+        if *line == "***************" {
+            has_ctx_sep = true;
+        }
+        if line.starts_with("*** ")
+            && !line.contains("****")
+            && i + 1 < lines.len()
+            && lines[i + 1].starts_with("--- ")
+        {
+            has_ctx_header = true;
+        }
     }
-    false
+    has_ctx_sep && has_ctx_header
 }
 
 /// Parse a unified or context diff into a list of per-file patches.
@@ -75,7 +108,13 @@ pub fn parse_patch(input: &str) -> Result<Vec<FilePatch>, PatchError> {
     }
 
     if is_context_diff(input) {
-        return parse_context_diff(input);
+        let patches = parse_context_diff(input)?;
+        if patches.is_empty() {
+            return Err(PatchError(
+                "no file headers or hunks found in context diff input".to_string(),
+            ));
+        }
+        return Ok(patches);
     }
 
     let patches = parse_unified_diff(input)?;

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -94,14 +94,14 @@ fn strip_ab_prefix(path: &str) -> &str {
         .unwrap_or(path)
 }
 
-/// Sanitize a path from a patch file: strip leading separators and reject `..` traversal.
+/// Sanitize a path from a patch file: strip leading separators, reject `..` traversal,
+/// and normalize backslashes to forward slashes for cross-platform consistency.
 ///
 /// Leading `/` and `\` characters are stripped to make absolute paths relative to the
 /// base directory (similar to `git apply -p0`). Returns `None` if the resulting path
 /// is empty, contains `..` components, or starts with a Windows drive letter.
-/// Handles both Unix and Windows path conventions.
 #[must_use]
-pub fn sanitize_patch_path(path: &str) -> Option<&str> {
+pub fn sanitize_patch_path(path: &str) -> Option<String> {
     // Strip leading slashes (Unix absolute) and backslashes (Windows absolute)
     let path = path.trim_start_matches(['/', '\\']);
     if path.is_empty() {
@@ -115,7 +115,9 @@ pub fn sanitize_patch_path(path: &str) -> Option<&str> {
     if path.split(['/', '\\']).any(|c| c == "..") {
         return None;
     }
-    Some(path)
+    // Normalize backslashes to forward slashes so Windows-produced patches
+    // create the correct directory structure on Unix
+    Some(path.replace('\\', "/"))
 }
 
 /// Strip a trailing tab-separated timestamp from a path (e.g. `file.txt\t2024-01-01 ...`).
@@ -552,8 +554,8 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError>
     }
 
     let mut result = output.join("\n");
-    // Preserve trailing newline if the original had one
-    if original.ends_with('\n') && !result.ends_with('\n') {
+    // Preserve trailing newline if the original had one, but not for empty output
+    if !result.is_empty() && original.ends_with('\n') && !result.ends_with('\n') {
         result.push('\n');
     }
     Ok(result)
@@ -632,8 +634,8 @@ pub fn apply_hunks_best_effort(original: &str, hunks: &[Hunk]) -> String {
     }
 
     let mut result = output.join("\n");
-    // Preserve trailing newline if the original had one
-    if original.ends_with('\n') && !result.ends_with('\n') {
+    // Preserve trailing newline if the original had one, but not for empty output
+    if !result.is_empty() && original.ends_with('\n') && !result.ends_with('\n') {
         result.push('\n');
     }
     result
@@ -1230,12 +1232,12 @@ fn main() {
 
     #[test]
     fn sanitize_normal_path() {
-        assert_eq!(sanitize_patch_path("src/main.rs"), Some("src/main.rs"));
+        assert_eq!(sanitize_patch_path("src/main.rs"), Some("src/main.rs".to_string()));
     }
 
     #[test]
     fn sanitize_strips_leading_slash() {
-        assert_eq!(sanitize_patch_path("/etc/passwd"), Some("etc/passwd"));
+        assert_eq!(sanitize_patch_path("/etc/passwd"), Some("etc/passwd".to_string()));
     }
 
     #[test]
@@ -1257,10 +1259,10 @@ fn main() {
     }
 
     #[test]
-    fn sanitize_strips_leading_backslash() {
+    fn sanitize_strips_leading_backslash_and_normalizes() {
         assert_eq!(
             sanitize_patch_path("\\usr\\bin\\foo"),
-            Some("usr\\bin\\foo")
+            Some("usr/bin/foo".to_string())
         );
     }
 
@@ -1336,16 +1338,16 @@ fn main() {
 
     #[test]
     fn sanitize_allows_hidden_files() {
-        assert_eq!(sanitize_patch_path(".gitignore"), Some(".gitignore"));
+        assert_eq!(sanitize_patch_path(".gitignore"), Some(".gitignore".to_string()));
         assert_eq!(
             sanitize_patch_path("src/.hidden/file.rs"),
-            Some("src/.hidden/file.rs")
+            Some("src/.hidden/file.rs".to_string())
         );
     }
 
     #[test]
     fn sanitize_allows_triple_dot() {
-        assert_eq!(sanitize_patch_path("src/.../foo"), Some("src/.../foo"));
+        assert_eq!(sanitize_patch_path("src/.../foo"), Some("src/.../foo".to_string()));
     }
 
     #[test]
@@ -1439,6 +1441,24 @@ fn main() {
             ],
         }];
         let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn apply_hunks_delete_everything_trailing_newline() {
+        let original = "a\nb\n";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 0,
+            lines: vec![
+                HunkLine::Remove("a".to_string()),
+                HunkLine::Remove("b".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        // Empty output should stay empty, not become "\n"
         assert_eq!(result, "");
     }
 

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -16,9 +16,17 @@ pub enum HunkLine {
     Remove(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchKind {
+    Modified,
+    Added,
+    Deleted,
+}
+
 #[derive(Debug, Clone)]
 pub struct FilePatch {
     pub original_path: String,
+    pub kind: PatchKind,
     pub hunks: Vec<Hunk>,
 }
 
@@ -252,6 +260,7 @@ fn parse_context_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
 
             patches.push(FilePatch {
                 original_path: old_path.to_string(),
+                kind: PatchKind::Modified,
                 hunks,
             });
         } else {
@@ -420,6 +429,13 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError>
         }
 
         // Copy unchanged lines before this hunk
+        if hunk_start > orig_lines.len() {
+            return Err(PatchError(format!(
+                "hunk references line {} but original has only {} lines",
+                hunk.old_start,
+                orig_lines.len()
+            )));
+        }
         for line in &orig_lines[pos..hunk_start] {
             output.push((*line).to_string());
         }
@@ -471,10 +487,26 @@ fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
     while i < lines.len() {
         // Look for a --- / +++ header pair.
         if lines[i].starts_with("--- ") && i + 1 < lines.len() && lines[i + 1].starts_with("+++ ") {
-            let old_path = &lines[i][4..];
-            let old_path = strip_timestamp(strip_ab_prefix(old_path.trim()));
+            let old_raw = lines[i][4..].trim();
+            let old_path = strip_timestamp(strip_ab_prefix(old_raw));
+            let new_raw = lines[i + 1][4..].trim();
+            let new_path = strip_timestamp(strip_ab_prefix(new_raw));
 
-            // Skip the +++ line (we use the old path as canonical).
+            let kind = if old_raw == "/dev/null" {
+                PatchKind::Added
+            } else if new_raw == "/dev/null" {
+                PatchKind::Deleted
+            } else {
+                PatchKind::Modified
+            };
+
+            // For added files, use the new path as canonical
+            let canonical_path = if kind == PatchKind::Added {
+                new_path
+            } else {
+                old_path
+            };
+
             i += 2;
 
             let mut hunks = Vec::new();
@@ -522,7 +554,8 @@ fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
             }
 
             patches.push(FilePatch {
-                original_path: old_path.to_string(),
+                original_path: canonical_path.to_string(),
+                kind,
                 hunks,
             });
         } else {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -88,6 +88,21 @@ fn strip_ab_prefix(path: &str) -> &str {
         .unwrap_or(path)
 }
 
+/// Sanitize a path from a patch file: reject absolute paths and `..` traversal.
+///
+/// Returns `None` if the path is unsafe (absolute or contains `..` components).
+#[must_use]
+pub fn sanitize_patch_path(path: &str) -> Option<&str> {
+    let path = path.trim_start_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+    if path.split('/').any(|c| c == "..") {
+        return None;
+    }
+    Some(path)
+}
+
 /// Strip a trailing tab-separated timestamp from a path (e.g. `file.txt\t2024-01-01 ...`).
 fn strip_timestamp(path: &str) -> &str {
     match path.find('\t') {
@@ -194,8 +209,24 @@ fn parse_context_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
             }
             // Check this is a file header, not a hunk range line.
             // Hunk range lines look like `*** 1,4 ****` — they end with `****`.
-            let old_path = strip_timestamp(lines[i][4..].trim());
-            let _new_path = strip_timestamp(lines[i + 1][4..].trim());
+            let old_raw = lines[i][4..].trim();
+            let old_path = strip_ab_prefix(strip_timestamp(old_raw));
+            let new_raw = lines[i + 1][4..].trim();
+            let new_path = strip_ab_prefix(strip_timestamp(new_raw));
+
+            let kind = if old_raw == "/dev/null" {
+                PatchKind::Added
+            } else if new_raw == "/dev/null" {
+                PatchKind::Deleted
+            } else {
+                PatchKind::Modified
+            };
+
+            let canonical_path = if kind == PatchKind::Added {
+                new_path
+            } else {
+                old_path
+            };
             i += 2;
 
             let mut hunks = Vec::new();
@@ -259,8 +290,8 @@ fn parse_context_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
             }
 
             patches.push(FilePatch {
-                original_path: old_path.to_string(),
-                kind: PatchKind::Modified,
+                original_path: canonical_path.to_string(),
+                kind,
                 hunks,
             });
         } else {
@@ -476,7 +507,12 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError>
         output.push((*line).to_string());
     }
 
-    Ok(output.join("\n"))
+    let mut result = output.join("\n");
+    // Preserve trailing newline if the original had one
+    if original.ends_with('\n') && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    Ok(result)
 }
 
 /// Try to apply each hunk individually. Hunks that apply cleanly are applied;
@@ -551,7 +587,12 @@ pub fn apply_hunks_best_effort(original: &str, hunks: &[Hunk]) -> String {
         output.push((*line).to_string());
     }
 
-    output.join("\n")
+    let mut result = output.join("\n");
+    // Preserve trailing newline if the original had one
+    if original.ends_with('\n') && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result
 }
 
 /// Check whether a hunk can be applied cleanly at the given position.
@@ -1079,7 +1120,7 @@ fn main() {
             ],
         }];
         let result = apply_hunks_best_effort(original, &hunks);
-        assert_eq!(result, "line1\nLINE2\nline3");
+        assert_eq!(result, "line1\nLINE2\nline3\n");
     }
 
     #[test]
@@ -1139,5 +1180,85 @@ fn main() {
         // Second hunk has conflict markers
         assert!(result.contains("<<<<<<< original"));
         assert!(result.contains(">>>>>>> patch"));
+    }
+
+    // ── sanitize_patch_path tests ────────────────────────────────────
+
+    #[test]
+    fn sanitize_normal_path() {
+        assert_eq!(sanitize_patch_path("src/main.rs"), Some("src/main.rs"));
+    }
+
+    #[test]
+    fn sanitize_strips_leading_slash() {
+        assert_eq!(sanitize_patch_path("/etc/passwd"), Some("etc/passwd"));
+    }
+
+    #[test]
+    fn sanitize_rejects_dotdot() {
+        assert_eq!(sanitize_patch_path("../../../etc/passwd"), None);
+        assert_eq!(sanitize_patch_path("src/../../../etc/passwd"), None);
+    }
+
+    #[test]
+    fn sanitize_rejects_empty() {
+        assert_eq!(sanitize_patch_path(""), None);
+        assert_eq!(sanitize_patch_path("/"), None);
+    }
+
+    // ── trailing newline preservation ────────────────────────────────
+
+    #[test]
+    fn apply_hunks_preserves_trailing_newline() {
+        let original = "line1\nline2\n";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("line2".to_string()),
+                HunkLine::Add("LINE2".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nLINE2\n");
+    }
+
+    #[test]
+    fn apply_hunks_no_trailing_newline_when_original_lacks_it() {
+        let original = "line1\nline2";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![
+                HunkLine::Remove("line2".to_string()),
+                HunkLine::Add("LINE2".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nLINE2");
+    }
+
+    // ── context diff Added/Deleted detection ─────────────────────────
+
+    #[test]
+    fn context_diff_added_file() {
+        let input = "*** /dev/null\n--- b/new_file.txt\n***************\n*** 0 ****\n--- 1,2 ----\n+ hello\n+ world\n";
+        let patches = parse_patch(input).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].kind, PatchKind::Added);
+        assert_eq!(patches[0].original_path, "new_file.txt");
+    }
+
+    #[test]
+    fn context_diff_deleted_file() {
+        let input = "*** a/old_file.txt\n--- /dev/null\n***************\n*** 1,2 ****\n- hello\n- world\n--- 0 ----\n";
+        let patches = parse_patch(input).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].kind, PatchKind::Deleted);
+        assert_eq!(patches[0].original_path, "old_file.txt");
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -479,6 +479,116 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError>
     Ok(output.join("\n"))
 }
 
+/// Try to apply each hunk individually. Hunks that apply cleanly are applied;
+/// hunks that fail are inserted as conflict markers at the expected location.
+/// Returns the result text — never fails.
+#[must_use]
+pub fn apply_hunks_best_effort(original: &str, hunks: &[Hunk]) -> String {
+    let orig_lines: Vec<&str> = if original.is_empty() {
+        Vec::new()
+    } else {
+        original.lines().collect()
+    };
+    let mut output: Vec<String> = Vec::new();
+    let mut pos: usize = 0;
+
+    for hunk in hunks {
+        let hunk_start = if hunk.old_start == 0 {
+            0
+        } else {
+            hunk.old_start.saturating_sub(1)
+        };
+
+        // If hunk starts before our position (overlap) or beyond file end,
+        // emit it as a rejected hunk at current position.
+        if hunk_start < pos || hunk_start > orig_lines.len() {
+            emit_conflict(&mut output, &[], &hunk.lines);
+            continue;
+        }
+
+        // Copy unchanged lines before this hunk
+        for line in &orig_lines[pos..hunk_start] {
+            output.push((*line).to_string());
+        }
+        pos = hunk_start;
+
+        // Try to apply this hunk
+        if try_apply_hunk(&orig_lines, pos, hunk) {
+            // Hunk applies cleanly
+            for hl in &hunk.lines {
+                match hl {
+                    HunkLine::Context(text) => {
+                        output.push(text.clone());
+                        pos += 1;
+                    }
+                    HunkLine::Remove(_) => {
+                        pos += 1;
+                    }
+                    HunkLine::Add(text) => {
+                        output.push(text.clone());
+                    }
+                }
+            }
+        } else {
+            // Hunk fails — emit conflict markers
+            let old_count = hunk
+                .lines
+                .iter()
+                .filter(|l| matches!(l, HunkLine::Context(_) | HunkLine::Remove(_)))
+                .count();
+            let end = (pos + old_count).min(orig_lines.len());
+            let original_section: Vec<String> = orig_lines[pos..end]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect();
+            emit_conflict(&mut output, &original_section, &hunk.lines);
+            pos = end;
+        }
+    }
+
+    // Copy remaining original lines
+    for line in &orig_lines[pos..] {
+        output.push((*line).to_string());
+    }
+
+    output.join("\n")
+}
+
+/// Check whether a hunk can be applied cleanly at the given position.
+fn try_apply_hunk(orig_lines: &[&str], mut pos: usize, hunk: &Hunk) -> bool {
+    for hl in &hunk.lines {
+        match hl {
+            HunkLine::Context(text) | HunkLine::Remove(text) => {
+                if pos >= orig_lines.len() || orig_lines[pos] != text.as_str() {
+                    return false;
+                }
+                pos += 1;
+            }
+            HunkLine::Add(_) => {}
+        }
+    }
+    true
+}
+
+/// Emit a conflict block with the original lines and the patch's intended changes.
+fn emit_conflict(output: &mut Vec<String>, original_lines: &[String], hunk_lines: &[HunkLine]) {
+    output.push("<<<<<<< original".to_string());
+    for line in original_lines {
+        output.push(line.clone());
+    }
+    output.push("=======".to_string());
+    // Show what the patch wanted: context + added lines (skip removed)
+    for hl in hunk_lines {
+        match hl {
+            HunkLine::Context(text) | HunkLine::Add(text) => {
+                output.push(text.clone());
+            }
+            HunkLine::Remove(_) => {}
+        }
+    }
+    output.push(">>>>>>> patch".to_string());
+}
+
 fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
     let lines: Vec<&str> = input.lines().collect();
     let mut patches = Vec::new();
@@ -949,5 +1059,85 @@ fn main() {
         assert_eq!(patches.len(), 1);
         let result = apply_hunks(original, &patches[0].hunks).unwrap();
         assert_eq!(result, "keep1\nkeep2");
+    }
+
+    // ── Best-effort apply tests ──────────────────────────────────────
+
+    #[test]
+    fn best_effort_clean_apply() {
+        let original = "line1\nline2\nline3\n";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: vec![
+                HunkLine::Context("line1".to_string()),
+                HunkLine::Remove("line2".to_string()),
+                HunkLine::Add("LINE2".to_string()),
+                HunkLine::Context("line3".to_string()),
+            ],
+        }];
+        let result = apply_hunks_best_effort(original, &hunks);
+        assert_eq!(result, "line1\nLINE2\nline3");
+    }
+
+    #[test]
+    fn best_effort_conflict_markers() {
+        let original = "aaa\nbbb\nccc\n";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: vec![
+                HunkLine::Context("aaa".to_string()),
+                HunkLine::Remove("WRONG".to_string()),
+                HunkLine::Add("NEW".to_string()),
+                HunkLine::Context("ccc".to_string()),
+            ],
+        }];
+        let result = apply_hunks_best_effort(original, &hunks);
+        assert!(result.contains("<<<<<<< original"));
+        assert!(result.contains("======="));
+        assert!(result.contains(">>>>>>> patch"));
+        assert!(result.contains("bbb")); // original line in conflict
+        assert!(result.contains("NEW")); // patched line in conflict
+    }
+
+    #[test]
+    fn best_effort_partial_apply() {
+        // Two hunks: first applies, second conflicts
+        let original = "a\nb\nc\nd\ne\nf\n";
+        let hunks = vec![
+            Hunk {
+                old_start: 1,
+                old_count: 2,
+                new_start: 1,
+                new_count: 2,
+                lines: vec![
+                    HunkLine::Remove("a".to_string()),
+                    HunkLine::Add("A".to_string()),
+                    HunkLine::Context("b".to_string()),
+                ],
+            },
+            Hunk {
+                old_start: 5,
+                old_count: 2,
+                new_start: 5,
+                new_count: 2,
+                lines: vec![
+                    HunkLine::Remove("WRONG".to_string()),
+                    HunkLine::Add("E".to_string()),
+                    HunkLine::Context("f".to_string()),
+                ],
+            },
+        ];
+        let result = apply_hunks_best_effort(original, &hunks);
+        // First hunk applied cleanly
+        assert!(result.starts_with("A\nb\nc\nd\n"));
+        // Second hunk has conflict markers
+        assert!(result.contains("<<<<<<< original"));
+        assert!(result.contains(">>>>>>> patch"));
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -91,13 +91,23 @@ fn strip_ab_prefix(path: &str) -> &str {
 /// Sanitize a path from a patch file: reject absolute paths and `..` traversal.
 ///
 /// Returns `None` if the path is unsafe (absolute or contains `..` components).
+/// Handles both Unix (`/`, `..`) and Windows (`\`, `C:`) path conventions.
 #[must_use]
 pub fn sanitize_patch_path(path: &str) -> Option<&str> {
-    let path = path.trim_start_matches('/');
+    // Strip leading slashes (Unix absolute) and backslashes (Windows absolute)
+    let path = path.trim_start_matches(['/', '\\']);
     if path.is_empty() {
         return None;
     }
-    if path.split('/').any(|c| c == "..") {
+    // Reject Windows drive letters (e.g. "C:", "D:")
+    if path.len() >= 2 && path.as_bytes()[0].is_ascii_alphabetic() && path.as_bytes()[1] == b':' {
+        return None;
+    }
+    // Reject `..` as a component with either separator
+    if path
+        .split(['/', '\\'])
+        .any(|c| c == "..")
+    {
         return None;
     }
     Some(path)
@@ -1201,9 +1211,30 @@ fn main() {
     }
 
     #[test]
+    fn sanitize_rejects_windows_backslash_traversal() {
+        assert_eq!(sanitize_patch_path("..\\..\\etc\\passwd"), None);
+        assert_eq!(sanitize_patch_path("src\\..\\..\\etc\\passwd"), None);
+    }
+
+    #[test]
+    fn sanitize_rejects_windows_drive_letter() {
+        assert_eq!(sanitize_patch_path("C:\\tmp\\owned.txt"), None);
+        assert_eq!(sanitize_patch_path("D:\\Windows\\System32\\config"), None);
+    }
+
+    #[test]
+    fn sanitize_strips_leading_backslash() {
+        assert_eq!(
+            sanitize_patch_path("\\usr\\bin\\foo"),
+            Some("usr\\bin\\foo")
+        );
+    }
+
+    #[test]
     fn sanitize_rejects_empty() {
         assert_eq!(sanitize_patch_path(""), None);
         assert_eq!(sanitize_patch_path("/"), None);
+        assert_eq!(sanitize_patch_path("\\"), None);
     }
 
     // ── trailing newline preservation ────────────────────────────────

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -33,9 +33,9 @@ impl fmt::Display for PatchError {
 
 impl std::error::Error for PatchError {}
 
-/// Returns true if the input looks like a context diff (not yet supported).
-fn is_context_diff(_input: &str) -> bool {
-    false
+/// Returns true if the input looks like a context diff.
+fn is_context_diff(input: &str) -> bool {
+    input.lines().any(|l| l == "***************")
 }
 
 /// Parse a unified or context diff into a list of per-file patches.
@@ -49,9 +49,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<FilePatch>, PatchError> {
     }
 
     if is_context_diff(input) {
-        return Err(PatchError(
-            "context diffs are not yet supported".to_string(),
-        ));
+        return parse_context_diff(input);
     }
 
     parse_unified_diff(input)
@@ -119,6 +117,256 @@ fn parse_range(range: &str, line: &str) -> Result<(usize, usize), PatchError> {
             .map_err(|_| PatchError(format!("invalid range number in: {line}")))?;
         Ok((start, 1))
     }
+}
+
+/// Parse a context-range header like `*** 1,4 ****` or `--- 5 ----` into `(start, count)`.
+/// Context diff ranges are inclusive (start through end), so count = end - start + 1.
+/// A single number means one line, so count = 1.
+fn parse_context_range(line: &str) -> Result<(usize, usize), PatchError> {
+    // Extract the numeric part between the prefix stars/dashes and the trailing stars/dashes.
+    let inner = line
+        .trim_start_matches(['*', '-', ' '])
+        .trim_end_matches(['*', '-', ' ']);
+    if inner.is_empty() {
+        // Empty section (e.g. pure addition with `*** 0 ****`)
+        return Ok((0, 0));
+    }
+    if let Some((start_s, end_s)) = inner.split_once(',') {
+        let start = start_s
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid context range: {line}")))?;
+        let end = end_s
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid context range: {line}")))?;
+        Ok((start, end - start + 1))
+    } else {
+        let start = inner
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| PatchError(format!("invalid context range: {line}")))?;
+        if start == 0 {
+            Ok((0, 0))
+        } else {
+            Ok((start, 1))
+        }
+    }
+}
+
+fn parse_context_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut patches = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        // Look for file header: `*** old_file` followed by `--- new_file`.
+        if lines[i].starts_with("*** ") && !lines[i].contains("****") {
+            if i + 1 >= lines.len() || !lines[i + 1].starts_with("--- ") {
+                i += 1;
+                continue;
+            }
+            // Check this is a file header, not a hunk range line.
+            // Hunk range lines look like `*** 1,4 ****` — they end with `****`.
+            let old_path = strip_timestamp(lines[i][4..].trim());
+            let _new_path = strip_timestamp(lines[i + 1][4..].trim());
+            i += 2;
+
+            let mut hunks = Vec::new();
+
+            // Parse hunks separated by `***************`.
+            while i < lines.len() && lines[i] == "***************" {
+                i += 1;
+                if i >= lines.len() {
+                    break;
+                }
+
+                // Old section: `*** start,end ****`
+                if !lines[i].starts_with("*** ") {
+                    return Err(PatchError(format!(
+                        "expected old section header, got: {}",
+                        lines[i]
+                    )));
+                }
+                let (old_start, old_count) = parse_context_range(lines[i])?;
+                i += 1;
+
+                // Collect old section lines until we hit `--- start,end ----`.
+                let mut old_lines: Vec<&str> = Vec::new();
+                while i < lines.len() && !lines[i].starts_with("--- ") {
+                    old_lines.push(lines[i]);
+                    i += 1;
+                }
+
+                // New section: `--- start,end ----`
+                if i >= lines.len() || !lines[i].starts_with("--- ") {
+                    return Err(PatchError(
+                        "expected new section header in context hunk".to_string(),
+                    ));
+                }
+                let (new_start, new_count) = parse_context_range(lines[i])?;
+                i += 1;
+
+                // Collect new section lines until next hunk separator or file header.
+                let mut new_lines: Vec<&str> = Vec::new();
+                while i < lines.len()
+                    && lines[i] != "***************"
+                    && !(lines[i].starts_with("*** ")
+                        && !lines[i].contains("****")
+                        && i + 1 < lines.len()
+                        && lines[i + 1].starts_with("--- "))
+                {
+                    new_lines.push(lines[i]);
+                    i += 1;
+                }
+
+                // Merge old and new sections into HunkLine list.
+                let hunk_lines = merge_context_sections(&old_lines, &new_lines)?;
+
+                hunks.push(Hunk {
+                    old_start,
+                    old_count,
+                    new_start,
+                    new_count,
+                    lines: hunk_lines,
+                });
+            }
+
+            patches.push(FilePatch {
+                original_path: old_path.to_string(),
+                hunks,
+            });
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(patches)
+}
+
+/// Classify a context diff line by its two-character prefix.
+enum CtxLineKind {
+    Context,
+    Changed,
+    Added,
+    Removed,
+}
+
+fn classify_context_line(line: &str) -> Option<(CtxLineKind, &str)> {
+    if let Some(rest) = line.strip_prefix("  ") {
+        Some((CtxLineKind::Context, rest))
+    } else if let Some(rest) = line.strip_prefix("! ") {
+        Some((CtxLineKind::Changed, rest))
+    } else if let Some(rest) = line.strip_prefix("+ ") {
+        Some((CtxLineKind::Added, rest))
+    } else if let Some(rest) = line.strip_prefix("- ") {
+        Some((CtxLineKind::Removed, rest))
+    } else {
+        None
+    }
+}
+
+/// Merge old-section and new-section lines into a unified `HunkLine` list.
+///
+/// Context lines appear in both sections (we take them from whichever has them).
+/// `!` (changed) lines in the old section become `Remove`, in the new section become `Add`.
+/// `-` lines in the old section become `Remove`, `+` lines in the new section become `Add`.
+fn merge_context_sections(
+    old_lines: &[&str],
+    new_lines: &[&str],
+) -> Result<Vec<HunkLine>, PatchError> {
+    let mut result = Vec::new();
+    let mut oi = 0;
+    let mut ni = 0;
+
+    while oi < old_lines.len() || ni < new_lines.len() {
+        // If old section is exhausted, drain new section.
+        if oi >= old_lines.len() {
+            while ni < new_lines.len() {
+                let (kind, text) = classify_context_line(new_lines[ni])
+                    .ok_or_else(|| PatchError(format!("bad context line: {}", new_lines[ni])))?;
+                match kind {
+                    CtxLineKind::Context => result.push(HunkLine::Context(text.to_string())),
+                    CtxLineKind::Added | CtxLineKind::Changed => {
+                        result.push(HunkLine::Add(text.to_string()));
+                    }
+                    CtxLineKind::Removed => result.push(HunkLine::Remove(text.to_string())),
+                }
+                ni += 1;
+            }
+            break;
+        }
+        // If new section is exhausted, drain old section.
+        if ni >= new_lines.len() {
+            while oi < old_lines.len() {
+                let (kind, text) = classify_context_line(old_lines[oi])
+                    .ok_or_else(|| PatchError(format!("bad context line: {}", old_lines[oi])))?;
+                match kind {
+                    CtxLineKind::Context => result.push(HunkLine::Context(text.to_string())),
+                    CtxLineKind::Removed | CtxLineKind::Changed => {
+                        result.push(HunkLine::Remove(text.to_string()));
+                    }
+                    CtxLineKind::Added => result.push(HunkLine::Add(text.to_string())),
+                }
+                oi += 1;
+            }
+            break;
+        }
+
+        let old_class = classify_context_line(old_lines[oi]);
+        let new_class = classify_context_line(new_lines[ni]);
+
+        match (&old_class, &new_class) {
+            // Changed lines: old `!` become Remove, new `!` become Add.
+            (Some((CtxLineKind::Changed, _)), _) => {
+                // Emit all consecutive old `!` lines as Remove.
+                while oi < old_lines.len() {
+                    if let Some((CtxLineKind::Changed, text)) = classify_context_line(old_lines[oi])
+                    {
+                        result.push(HunkLine::Remove(text.to_string()));
+                        oi += 1;
+                    } else {
+                        break;
+                    }
+                }
+                // Emit all consecutive new `!` lines as Add.
+                while ni < new_lines.len() {
+                    if let Some((CtxLineKind::Changed, text)) = classify_context_line(new_lines[ni])
+                    {
+                        result.push(HunkLine::Add(text.to_string()));
+                        ni += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // Old section has removed lines.
+            (Some((CtxLineKind::Removed, text)), _) => {
+                result.push(HunkLine::Remove(text.to_string()));
+                oi += 1;
+            }
+            // New section has added lines.
+            (_, Some((CtxLineKind::Added, text))) => {
+                result.push(HunkLine::Add(text.to_string()));
+                ni += 1;
+            }
+            // Context in old, something else in new — emit old context and advance both.
+            (Some((CtxLineKind::Context, text)), _) => {
+                result.push(HunkLine::Context(text.to_string()));
+                oi += 1;
+                ni += 1;
+            }
+            _ => {
+                return Err(PatchError(format!(
+                    "unexpected context diff line combination: {:?} / {:?}",
+                    old_lines.get(oi),
+                    new_lines.get(ni)
+                )));
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
@@ -269,6 +517,71 @@ mod tests {
         let patches = parse_patch(diff).unwrap();
         assert_eq!(patches.len(), 1);
         assert_eq!(patches[0].original_path, "hello.txt");
+    }
+
+    #[test]
+    fn parse_context_single_file() {
+        let diff = "\
+*** hello.txt\t2024-01-01 00:00:00.000000000 +0000
+--- hello.txt\t2024-01-02 00:00:00.000000000 +0000
+***************
+*** 1,4 ****
+  line1
+! line2
+  line3
+  line4
+--- 1,4 ----
+  line1
+! line2modified
+  line3
+  line4
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].original_path, "hello.txt");
+        assert_eq!(patches[0].hunks.len(), 1);
+
+        let hunk = &patches[0].hunks[0];
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.old_count, 4);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.new_count, 4);
+        assert_eq!(hunk.lines.len(), 5);
+
+        assert!(matches!(&hunk.lines[0], HunkLine::Context(s) if s == "line1"));
+        assert!(matches!(&hunk.lines[1], HunkLine::Remove(s) if s == "line2"));
+        assert!(matches!(&hunk.lines[2], HunkLine::Add(s) if s == "line2modified"));
+        assert!(matches!(&hunk.lines[3], HunkLine::Context(s) if s == "line3"));
+        assert!(matches!(&hunk.lines[4], HunkLine::Context(s) if s == "line4"));
+    }
+
+    #[test]
+    fn parse_context_add_only() {
+        let diff = "\
+*** hello.txt\t2024-01-01 00:00:00.000000000 +0000
+--- hello.txt\t2024-01-02 00:00:00.000000000 +0000
+***************
+*** 1,2 ****
+--- 1,4 ----
+  line1
++ added1
++ added2
+  line2
+";
+        let patches = parse_patch(diff).unwrap();
+        assert_eq!(patches.len(), 1);
+
+        let hunk = &patches[0].hunks[0];
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.old_count, 2);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.new_count, 4);
+        assert_eq!(hunk.lines.len(), 4);
+
+        assert!(matches!(&hunk.lines[0], HunkLine::Context(s) if s == "line1"));
+        assert!(matches!(&hunk.lines[1], HunkLine::Add(s) if s == "added1"));
+        assert!(matches!(&hunk.lines[2], HunkLine::Add(s) if s == "added2"));
+        assert!(matches!(&hunk.lines[3], HunkLine::Context(s) if s == "line2"));
     }
 
     #[test]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -78,7 +78,13 @@ pub fn parse_patch(input: &str) -> Result<Vec<FilePatch>, PatchError> {
         return parse_context_diff(input);
     }
 
-    parse_unified_diff(input)
+    let patches = parse_unified_diff(input)?;
+    if patches.is_empty() {
+        return Err(PatchError(
+            "no file headers or hunks found in patch input".to_string(),
+        ));
+    }
+    Ok(patches)
 }
 
 /// Strip an optional `a/` or `b/` prefix from a path.

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -234,9 +234,9 @@ fn parse_context_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
             let new_raw = lines[i + 1][4..].trim();
             let new_path = strip_ab_prefix(strip_timestamp(new_raw));
 
-            let kind = if old_raw == "/dev/null" {
+            let kind = if old_path == "/dev/null" || old_path == "dev/null" {
                 PatchKind::Added
-            } else if new_raw == "/dev/null" {
+            } else if new_path == "/dev/null" || new_path == "dev/null" {
                 PatchKind::Deleted
             } else {
                 PatchKind::Modified
@@ -520,6 +520,30 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, PatchError>
                 }
             }
         }
+
+        // Validate consumed old/new line counts match hunk header
+        let actual_old = hunk
+            .lines
+            .iter()
+            .filter(|l| matches!(l, HunkLine::Context(_) | HunkLine::Remove(_)))
+            .count();
+        let actual_new = hunk
+            .lines
+            .iter()
+            .filter(|l| matches!(l, HunkLine::Context(_) | HunkLine::Add(_)))
+            .count();
+        if actual_old != hunk.old_count {
+            return Err(PatchError(format!(
+                "hunk at line {}: expected {} old lines but found {}",
+                hunk.old_start, hunk.old_count, actual_old
+            )));
+        }
+        if actual_new != hunk.new_count {
+            return Err(PatchError(format!(
+                "hunk at line {}: expected {} new lines but found {}",
+                hunk.new_start, hunk.new_count, actual_new
+            )));
+        }
     }
 
     // Copy remaining original lines after the last hunk
@@ -663,9 +687,9 @@ fn parse_unified_diff(input: &str) -> Result<Vec<FilePatch>, PatchError> {
             let new_raw = lines[i + 1][4..].trim();
             let new_path = strip_timestamp(strip_ab_prefix(new_raw));
 
-            let kind = if old_raw == "/dev/null" {
+            let kind = if old_path == "/dev/null" || old_path == "dev/null" {
                 PatchKind::Added
-            } else if new_raw == "/dev/null" {
+            } else if new_path == "/dev/null" || new_path == "dev/null" {
                 PatchKind::Deleted
             } else {
                 PatchKind::Modified

--- a/src/ui/common/mod.rs
+++ b/src/ui/common/mod.rs
@@ -39,6 +39,7 @@ mod tests;
 pub(super) enum FileStatus {
     Same,
     Different,
+    Conflict,
     LeftOnly,
     RightOnly,
 }
@@ -48,6 +49,7 @@ impl FileStatus {
         match self {
             Self::Same => "S",
             Self::Different => "D",
+            Self::Conflict => "C",
             Self::LeftOnly => "L",
             Self::RightOnly => "R",
         }

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -998,13 +998,15 @@ pub(super) fn build_diff_view(
                 if c.tag == DiffTag::Equal {
                     continue;
                 }
-                // Skip chunks whose right-side text contains conflict markers
-                // (from best-effort patch application). Check for line-start
-                // markers rather than exact strings to avoid false positives.
+                // Skip chunks containing any conflict marker line (from
+                // best-effort patch application). A conflict block may span
+                // multiple diff chunks, so skip on any marker, not just pairs.
                 let src_text = get_lines_text(&rb, c.start_b, c.end_b);
-                if src_text.lines().any(|l| l.starts_with("<<<<<<<"))
-                    && src_text.lines().any(|l| l.starts_with(">>>>>>>"))
-                {
+                if src_text.lines().any(|l| {
+                    l.starts_with("<<<<<<<")
+                        || l.starts_with(">>>>>>>")
+                        || l == "======="
+                }) {
                     continue;
                 }
                 copy_chunk(&rb, c.start_b, c.end_b, &lb, c.start_a, c.end_a);

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -384,7 +384,15 @@ pub(super) fn build_diff_view(
     toolbar.append(&chunk_label);
     toolbar.append(&goto_entry);
     toolbar.append(&filter_box);
+    let apply_all_btn = Button::from_icon_name("media-skip-backward-symbolic");
+    apply_all_btn.set_tooltip_text(Some("Apply all non-conflicting changes right → left"));
+    apply_all_btn.set_action_name(Some("diff.apply-all-right-to-left"));
+    if any_binary {
+        apply_all_btn.set_sensitive(false);
+    }
+
     toolbar.append(&patch_btn);
+    toolbar.append(&apply_all_btn);
     toolbar.append(&swap_btn);
     let prefs_btn = Button::from_icon_name("preferences-system-symbolic");
     prefs_btn.set_tooltip_text(Some(&format!("Preferences ({}+,)", primary_key_name())));
@@ -975,6 +983,33 @@ pub(super) fn build_diff_view(
         action_group.add_action(&action);
     }
 
+    // Apply all non-conflicting: copy every non-equal, non-conflict chunk R→L
+    // as a single undo operation.
+    {
+        let action = gio::SimpleAction::new("apply-all-right-to-left", None);
+        let ch = chunks.clone();
+        let lb = left_buf.clone();
+        let rb = right_buf.clone();
+        action.connect_activate(move |_, _| {
+            let snapshot = ch.borrow();
+            lb.begin_user_action();
+            // Reverse order so line numbers stay valid
+            for c in snapshot.iter().rev() {
+                if c.tag == DiffTag::Equal {
+                    continue;
+                }
+                // Skip chunks whose right-side text contains conflict markers
+                let src_text = get_lines_text(&rb, c.start_b, c.end_b);
+                if src_text.contains("<<<<<<< original") && src_text.contains(">>>>>>> patch") {
+                    continue;
+                }
+                copy_chunk(&rb, c.start_b, c.end_b, &lb, c.start_a, c.end_a);
+            }
+            lb.end_user_action();
+        });
+        action_group.add_action(&action);
+    }
+
     // Ctrl+S: save the focused pane
     {
         let action = gio::SimpleAction::new("save", None);
@@ -1163,6 +1198,7 @@ pub(super) fn open_file_diff(
     open_tabs: &Rc<RefCell<Vec<FileTab>>>,
     left_dir: &str,
     right_dir: &str,
+    labels: &[String],
     settings: &Rc<RefCell<Settings>>,
 ) {
     // Switch to existing tab if this file is already open
@@ -1176,10 +1212,13 @@ pub(super) fn open_file_diff(
         }
     }
 
-    let left_path = Path::new(left_dir).join(rel_path);
-    let right_path = Path::new(right_dir).join(rel_path);
+    // Resolve symlinks so headers/tooltips/save-dialogs show original paths
+    let left_raw = Path::new(left_dir).join(rel_path);
+    let right_raw = Path::new(right_dir).join(rel_path);
+    let left_path = std::fs::canonicalize(&left_raw).unwrap_or(left_raw);
+    let right_path = std::fs::canonicalize(&right_raw).unwrap_or(right_raw);
 
-    let dv = build_diff_view(&left_path, &right_path, &[], settings);
+    let dv = build_diff_view(&left_path, &right_path, labels, settings);
     dv.widget
         .insert_action_group("diff", Some(&dv.action_group));
 
@@ -1201,10 +1240,16 @@ pub(super) fn open_file_diff(
         },
     });
 
-    // Tab label
+    // Tab label — use label overrides when available (e.g. patch mode)
     let file_name = display_name(Path::new(rel_path));
-    let left_dir_name = display_name(Path::new(left_dir));
-    let right_dir_name = display_name(Path::new(right_dir));
+    let left_dir_name = labels
+        .first()
+        .cloned()
+        .unwrap_or_else(|| display_name(Path::new(left_dir)));
+    let right_dir_name = labels
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| display_name(Path::new(right_dir)));
     let tab_title = format!("[{left_dir_name}] {file_name} — [{right_dir_name}] {file_name}");
 
     let (tab_label_box, close_btn) = make_closeable_tab_label(&tab_title);

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -17,6 +17,7 @@ type SwapCallback = Rc<RefCell<Option<Box<dyn Fn()>>>>;
 pub(super) struct DiffViewResult {
     pub(super) widget: GtkBox,
     pub(super) left_text_view: TextView,
+    pub(super) right_text_view: TextView,
     pub(super) left_buf: TextBuffer,
     pub(super) right_buf: TextBuffer,
     pub(super) left_save: Button,
@@ -1183,6 +1184,7 @@ pub(super) fn build_diff_view(
     DiffViewResult {
         widget,
         left_text_view: left_pane.text_view,
+        right_text_view: right_pane.text_view,
         left_buf,
         right_buf,
         left_save: left_pane.save_btn,

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -999,8 +999,12 @@ pub(super) fn build_diff_view(
                     continue;
                 }
                 // Skip chunks whose right-side text contains conflict markers
+                // (from best-effort patch application). Check for line-start
+                // markers rather than exact strings to avoid false positives.
                 let src_text = get_lines_text(&rb, c.start_b, c.end_b);
-                if src_text.contains("<<<<<<< original") && src_text.contains(">>>>>>> patch") {
+                if src_text.lines().any(|l| l.starts_with("<<<<<<<"))
+                    && src_text.lines().any(|l| l.starts_with(">>>>>>>"))
+                {
                     continue;
                 }
                 copy_chunk(&rb, c.start_b, c.end_b, &lb, c.start_a, c.end_a);

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -1003,11 +1003,10 @@ pub(super) fn build_diff_view(
                 // best-effort patch application). A conflict block may span
                 // multiple diff chunks, so skip on any marker, not just pairs.
                 let src_text = get_lines_text(&rb, c.start_b, c.end_b);
-                if src_text.lines().any(|l| {
-                    l.starts_with("<<<<<<<")
-                        || l.starts_with(">>>>>>>")
-                        || l == "======="
-                }) {
+                if src_text
+                    .lines()
+                    .any(|l| l.starts_with("<<<<<<<") || l.starts_with(">>>>>>>") || l == "=======")
+                {
                     continue;
                 }
                 copy_chunk(&rb, c.start_b, c.end_b, &lb, c.start_a, c.end_a);

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -132,7 +132,7 @@ fn read_dir_entries(
             let Ok(name) = entry.file_name().into_string() else {
                 continue;
             };
-            if name == ".mergers-conflicts" || dir_filters.iter().any(|f| f == &name) {
+            if dir_filters.iter().any(|f| f == &name) {
                 continue;
             }
             if hide_hidden && name.starts_with('.') {

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -284,23 +284,25 @@ fn scan_tree_inner(
                     }
                 }
                 (true, true) => {
-                    let lm = left_entries.get(*name);
-                    let rm = right_entries.get(*name);
-                    // Fast path: different sizes means different content
-                    if lm.and_then(|m| m.size) == rm.and_then(|m| m.size) {
-                        let lc = fs::read(left_dir.join(name)).unwrap_or_default();
-                        let rc = fs::read(right_dir.join(name)).unwrap_or_default();
-                        if lc == rc {
-                            FileStatus::Same
-                        } else if conflicts.contains(&child_rel) {
-                            FileStatus::Conflict
+                    // Check conflict marker first — conflicted files should
+                    // always show as Conflict even if contents are identical
+                    if conflicts.contains(&child_rel) {
+                        FileStatus::Conflict
+                    } else {
+                        let lm = left_entries.get(*name);
+                        let rm = right_entries.get(*name);
+                        // Fast path: different sizes means different content
+                        if lm.and_then(|m| m.size) == rm.and_then(|m| m.size) {
+                            let lc = fs::read(left_dir.join(name)).unwrap_or_default();
+                            let rc = fs::read(right_dir.join(name)).unwrap_or_default();
+                            if lc == rc {
+                                FileStatus::Same
+                            } else {
+                                FileStatus::Different
+                            }
                         } else {
                             FileStatus::Different
                         }
-                    } else if conflicts.contains(&child_rel) {
-                        FileStatus::Conflict
-                    } else {
-                        FileStatus::Different
                     }
                 }
                 _ => unreachable!(),

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -1126,6 +1126,11 @@ pub(super) fn build_dir_tab(
             let rd_str = rd.borrow().clone();
             let mut actionable: Vec<(String, FileStatus)> = Vec::new();
             collect_actionable_files(&rs, &cm.borrow(), &mut actionable);
+            // In non-patch mode, LeftOnly delete is not supported
+            let is_patch = base_dir_override.is_some();
+            if !is_patch {
+                actionable.retain(|(_, s)| *s != FileStatus::LeftOnly);
+            }
             if actionable.is_empty() {
                 return;
             }

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -1140,9 +1140,10 @@ pub(super) fn build_dir_tab(
                 for (rel, status) in &actionable {
                     let left_p = Path::new(&ld_str).join(rel);
                     let right_p = Path::new(&rd_str).join(rel);
+                    let is_patch = base_dir.is_some();
                     match status {
                         FileStatus::Different => {
-                            // Copy right → left (modified file; symlink follows to original)
+                            // Copy right → left (in patch mode, symlink follows to original)
                             if let Some(parent) = left_p.parent() {
                                 let _ = fs::create_dir_all(parent);
                             }
@@ -1150,12 +1151,14 @@ pub(super) fn build_dir_tab(
                                 errors.push(format!("{rel}: {e}"));
                                 continue;
                             }
-                            // Remove both sides so they vanish from the scan
-                            let _ = fs::remove_file(&left_p);
-                            let _ = fs::remove_file(&right_p);
+                            // In patch mode, remove temp entries so they vanish from scan
+                            if is_patch {
+                                let _ = fs::remove_file(&left_p);
+                                let _ = fs::remove_file(&right_p);
+                            }
                         }
                         FileStatus::RightOnly => {
-                            // New file — copy right to the real base dir if in patch mode,
+                            // New file — in patch mode copy to real base dir,
                             // otherwise copy to the left dir.
                             let target = if let Some(ref base) = base_dir {
                                 PathBuf::from(base).join(rel)
@@ -1169,18 +1172,19 @@ pub(super) fn build_dir_tab(
                                 errors.push(format!("{rel}: {e}"));
                                 continue;
                             }
-                            // Remove temp sides so they vanish from the scan
-                            let _ = fs::remove_file(&left_p);
-                            let _ = fs::remove_file(&right_p);
+                            // In patch mode, remove temp entries so they vanish from scan
+                            if is_patch {
+                                let _ = fs::remove_file(&left_p);
+                                let _ = fs::remove_file(&right_p);
+                            }
                         }
                         FileStatus::LeftOnly => {
-                            // Deleted file — remove the real file (resolve symlink in patch mode)
-                            if base_dir.is_some() {
-                                // In patch mode, left_p is a symlink; resolve to original
+                            if is_patch {
+                                // In patch mode, left_p is a symlink; resolve to delete original
                                 let real_path = fs::canonicalize(&left_p).unwrap_or(left_p.clone());
                                 let _ = fs::remove_file(&real_path);
+                                let _ = fs::remove_file(&left_p);
                             }
-                            let _ = fs::remove_file(&left_p);
                         }
                         FileStatus::Conflict | FileStatus::Same => {}
                     }

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -42,6 +42,7 @@ impl DirRowInfo {
 
         let status = match status_code {
             "D" => FileStatus::Different,
+            "C" => FileStatus::Conflict,
             "L" => FileStatus::LeftOnly,
             "R" => FileStatus::RightOnly,
             _ => FileStatus::Same,
@@ -93,6 +94,31 @@ fn copy_path_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Recursively collect `(rel_path, status)` of all non-conflicting, non-same files.
+fn collect_actionable_files(
+    store: &ListStore,
+    cm: &HashMap<String, ListStore>,
+    out: &mut Vec<(String, FileStatus)>,
+) {
+    for i in 0..store.n_items() {
+        if let Some(obj) = store.item(i).and_downcast::<StringObject>() {
+            let info = DirRowInfo::decode(&obj.string());
+            if info.is_dir {
+                if let Some(child_store) = cm.get(&info.rel_path) {
+                    collect_actionable_files(child_store, cm, out);
+                }
+            } else {
+                match info.status {
+                    FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly => {
+                        out.push((info.rel_path, info.status));
+                    }
+                    FileStatus::Conflict | FileStatus::Same => {}
+                }
+            }
+        }
+    }
+}
+
 // ─── Directory scanning ────────────────────────────────────────────────────
 
 fn read_dir_entries(
@@ -106,13 +132,15 @@ fn read_dir_entries(
             let Ok(name) = entry.file_name().into_string() else {
                 continue;
             };
-            if dir_filters.iter().any(|f| f == &name) {
+            if name == ".mergers-conflicts" || dir_filters.iter().any(|f| f == &name) {
                 continue;
             }
             if hide_hidden && name.starts_with('.') {
                 continue;
             }
-            let meta = entry.metadata().ok();
+            // Use fs::metadata (follows symlinks) instead of entry.metadata()
+            // which is equivalent to lstat and returns symlink metadata.
+            let meta = fs::metadata(entry.path()).ok();
             let is_dir = meta.as_ref().is_some_and(std::fs::Metadata::is_dir);
             map.insert(
                 name,
@@ -151,6 +179,35 @@ fn scan_tree(
     rel: &str,
     dir_filters: &[String],
     hide_hidden: bool,
+) -> (Vec<ScanEntry>, FileStatus) {
+    // Check for a conflicts marker file written by patch mode.
+    let conflicts = if rel.is_empty() {
+        let marker = right_root.join(".mergers-conflicts");
+        if let Ok(content) = fs::read_to_string(&marker) {
+            content.lines().map(String::from).collect()
+        } else {
+            HashSet::new()
+        }
+    } else {
+        HashSet::new()
+    };
+    scan_tree_inner(
+        left_root,
+        right_root,
+        rel,
+        dir_filters,
+        hide_hidden,
+        &conflicts,
+    )
+}
+
+fn scan_tree_inner(
+    left_root: &Path,
+    right_root: &Path,
+    rel: &str,
+    dir_filters: &[String],
+    hide_hidden: bool,
+    conflicts: &HashSet<String>,
 ) -> (Vec<ScanEntry>, FileStatus) {
     let left_dir = if rel.is_empty() {
         left_root.to_path_buf()
@@ -192,8 +249,14 @@ fn scan_tree(
 
         let (status, children);
         if *is_dir {
-            let (child_entries, child_agg) =
-                scan_tree(left_root, right_root, &child_rel, dir_filters, hide_hidden);
+            let (child_entries, child_agg) = scan_tree_inner(
+                left_root,
+                right_root,
+                &child_rel,
+                dir_filters,
+                hide_hidden,
+                conflicts,
+            );
             status = if !in_left {
                 FileStatus::RightOnly
             } else if !in_right {
@@ -216,9 +279,13 @@ fn scan_tree(
                         let rc = fs::read(right_dir.join(name)).unwrap_or_default();
                         if lc == rc {
                             FileStatus::Same
+                        } else if conflicts.contains(&child_rel) {
+                            FileStatus::Conflict
                         } else {
                             FileStatus::Different
                         }
+                    } else if conflicts.contains(&child_rel) {
+                        FileStatus::Conflict
                     } else {
                         FileStatus::Different
                     }
@@ -258,8 +325,16 @@ fn scan_tree(
 fn build_stores(entries: &[ScanEntry], children_map: &mut HashMap<String, ListStore>) -> ListStore {
     let store = ListStore::new::<StringObject>();
     for entry in entries {
+        // Skip Same entries — they have no visual purpose in the dir view
+        if entry.status == FileStatus::Same {
+            continue;
+        }
         if entry.is_dir {
             let child_store = build_stores(&entry.children, children_map);
+            // Skip empty directories (all children are Same)
+            if child_store.n_items() == 0 {
+                continue;
+            }
             children_map.insert(entry.rel_path.clone(), child_store);
         }
         let info = DirRowInfo {
@@ -282,6 +357,7 @@ fn build_stores(entries: &[ScanEntry], children_map: &mut HashMap<String, ListSt
 fn apply_status_class(widget: &impl WidgetExt, status: &str, is_left: bool) {
     for cls in &[
         "diff-changed",
+        "diff-conflict",
         "diff-deleted",
         "diff-inserted",
         "diff-missing",
@@ -291,6 +367,7 @@ fn apply_status_class(widget: &impl WidgetExt, status: &str, is_left: bool) {
     if is_left {
         match status {
             "D" => widget.add_css_class("diff-changed"),
+            "C" => widget.add_css_class("diff-conflict"),
             "L" => widget.add_css_class("diff-deleted"),
             "R" => widget.add_css_class("diff-missing"),
             _ => {}
@@ -298,6 +375,7 @@ fn apply_status_class(widget: &impl WidgetExt, status: &str, is_left: bool) {
     } else {
         match status {
             "D" => widget.add_css_class("diff-changed"),
+            "C" => widget.add_css_class("diff-conflict"),
             "R" => widget.add_css_class("diff-inserted"),
             "L" => widget.add_css_class("diff-missing"),
             _ => {}
@@ -400,6 +478,7 @@ pub(super) fn build_dir_tab(
     left_dir: std::path::PathBuf,
     right_dir: std::path::PathBuf,
     labels: &[String],
+    tooltip_dirs: &[String],
     settings: Rc<RefCell<Settings>>,
     notebook: &Notebook,
     open_tabs: &Rc<RefCell<Vec<FileTab>>>,
@@ -408,6 +487,8 @@ pub(super) fn build_dir_tab(
         Rc::new(RefCell::new(labels.first().cloned()));
     let right_label_override: Rc<RefCell<Option<String>>> =
         Rc::new(RefCell::new(labels.get(1).cloned()));
+    let left_tooltip_override: Option<String> = tooltip_dirs.first().cloned();
+    let right_tooltip_override: Option<String> = tooltip_dirs.get(1).cloned();
     let left_dir = Rc::new(RefCell::new(
         std::fs::canonicalize(&left_dir)
             .unwrap_or(left_dir)
@@ -660,7 +741,11 @@ pub(super) fn build_dir_tab(
         None => shortened_path(Path::new(&*left_dir.borrow())),
     };
     let left_header = Label::new(Some(&left_header_text));
-    left_header.set_tooltip_text(Some(&*left_dir.borrow()));
+    {
+        let ld = left_dir.borrow();
+        let left_tip = left_tooltip_override.as_deref().unwrap_or(&ld);
+        left_header.set_tooltip_text(Some(left_tip));
+    }
     left_header.set_ellipsize(gtk4::pango::EllipsizeMode::Start);
     left_header.set_hexpand(true);
     let left_copy_btn = Button::from_icon_name("edit-copy-symbolic");
@@ -685,7 +770,11 @@ pub(super) fn build_dir_tab(
         None => shortened_path(Path::new(&*right_dir.borrow())),
     };
     let right_header = Label::new(Some(&right_header_text));
-    right_header.set_tooltip_text(Some(&*right_dir.borrow()));
+    {
+        let rd = right_dir.borrow();
+        let right_tip = right_tooltip_override.as_deref().unwrap_or(&rd);
+        right_header.set_tooltip_text(Some(right_tip));
+    }
     right_header.set_ellipsize(gtk4::pango::EllipsizeMode::Start);
     right_header.set_hexpand(true);
     let right_copy_btn = Button::from_icon_name("edit-copy-symbolic");
@@ -752,8 +841,12 @@ pub(super) fn build_dir_tab(
     dir_prefs_btn.set_tooltip_text(Some(&format!("Preferences ({}+,)", primary_key_name())));
     dir_prefs_btn.set_action_name(Some("win.prefs"));
 
+    let apply_all_btn = Button::from_icon_name("media-skip-backward-symbolic");
+    apply_all_btn.set_tooltip_text(Some("Apply all non-conflicting changes right → left"));
+
     dir_toolbar.append(&dir_copy_box);
     dir_toolbar.append(&delete_btn);
+    dir_toolbar.append(&apply_all_btn);
     dir_toolbar.append(&dir_swap_btn);
     dir_toolbar.append(&tree_box);
     dir_toolbar.append(&dir_prefs_btn);
@@ -983,7 +1076,10 @@ pub(super) fn build_dir_tab(
         action.connect_activate(move |_, _| {
             if let Some(raw) = get_row() {
                 let info = DirRowInfo::decode(&raw);
-                if info.status == only_status || info.status == FileStatus::Different {
+                if info.status == only_status
+                    || info.status == FileStatus::Different
+                    || info.status == FileStatus::Conflict
+                {
                     let rel = info.rel_path;
                     let src = Path::new(sd.borrow().as_str()).join(&rel);
                     let dst = Path::new(dd.borrow().as_str()).join(&rel);
@@ -997,7 +1093,7 @@ pub(super) fn build_dir_tab(
                         }
                         reload();
                     };
-                    if info.status == FileStatus::Different {
+                    if info.status == FileStatus::Different || info.status == FileStatus::Conflict {
                         if let Some(win) = find_window(&lv) {
                             show_confirm_dialog(
                                 &win,
@@ -1014,6 +1110,72 @@ pub(super) fn build_dir_tab(
             }
         });
         dir_action_group.add_action(&action);
+    }
+    // Apply all: copy every non-conflicting changed file from right → left
+    {
+        let rs = root_store.clone();
+        let cm = children_map.clone();
+        let ld = left_dir.clone();
+        let rd = right_dir.clone();
+        let reload = reload_dir.clone();
+        let lv = left_view.clone();
+        apply_all_btn.connect_clicked(move |_| {
+            let ld_str = ld.borrow().clone();
+            let rd_str = rd.borrow().clone();
+            let mut actionable: Vec<(String, FileStatus)> = Vec::new();
+            collect_actionable_files(&rs, &cm.borrow(), &mut actionable);
+            if actionable.is_empty() {
+                return;
+            }
+            let count = actionable.len();
+            let reload = reload.clone();
+            let lv2 = lv.clone();
+            let do_apply = move || {
+                // Suppress file watcher during bulk operations
+                mark_saving(Path::new(&ld_str));
+                mark_saving(Path::new(&rd_str));
+                let mut errors = Vec::new();
+                for (rel, status) in &actionable {
+                    let left_p = Path::new(&ld_str).join(rel);
+                    let right_p = Path::new(&rd_str).join(rel);
+                    match status {
+                        FileStatus::Different | FileStatus::RightOnly => {
+                            // Copy right → left (modified or new file)
+                            if let Some(parent) = left_p.parent() {
+                                let _ = fs::create_dir_all(parent);
+                            }
+                            if let Err(e) = copy_path_recursive(&right_p, &left_p) {
+                                errors.push(format!("{rel}: {e}"));
+                                continue;
+                            }
+                            // Remove both sides so they vanish from the scan
+                            let _ = fs::remove_file(&left_p);
+                            let _ = fs::remove_file(&right_p);
+                        }
+                        FileStatus::LeftOnly => {
+                            // Deleted file — remove from left
+                            let _ = fs::remove_file(&left_p);
+                        }
+                        FileStatus::Conflict | FileStatus::Same => {}
+                    }
+                }
+                if !errors.is_empty()
+                    && let Some(win) = find_window(&lv2)
+                {
+                    show_error_dialog(&win, &errors.join("\n"));
+                }
+                reload();
+            };
+            if let Some(win) = find_window(&lv) {
+                show_confirm_dialog(
+                    &win,
+                    &format!("Apply {count} file(s)?"),
+                    "Non-conflicting changes will be applied (copy, create, or delete).",
+                    "Apply",
+                    do_apply,
+                );
+            }
+        });
     }
     {
         let action = gio::SimpleAction::new("folder-delete", None);
@@ -1033,7 +1195,7 @@ pub(super) fn build_dir_tab(
                 let path = match status {
                     FileStatus::LeftOnly => Some(lp),
                     FileStatus::RightOnly => Some(rp),
-                    FileStatus::Different | FileStatus::Same => {
+                    FileStatus::Different | FileStatus::Conflict | FileStatus::Same => {
                         Some(if fl.get() { lp } else { rp })
                     }
                 };
@@ -1133,17 +1295,14 @@ pub(super) fn build_dir_tab(
                 let info = DirRowInfo::decode(&raw);
                 let lp = Path::new(ld.borrow().as_str()).join(&info.rel_path);
                 let rp = Path::new(rd.borrow().as_str()).join(&info.rel_path);
-                let path = match info.status {
-                    FileStatus::LeftOnly => lp,
-                    FileStatus::RightOnly => rp,
-                    FileStatus::Different | FileStatus::Same => {
-                        if fl.get() {
-                            lp
-                        } else {
-                            rp
+                let path =
+                    match info.status {
+                        FileStatus::LeftOnly => lp,
+                        FileStatus::RightOnly => rp,
+                        FileStatus::Different | FileStatus::Conflict | FileStatus::Same => {
+                            if fl.get() { lp } else { rp }
                         }
-                    }
-                };
+                    };
                 let abs = path.canonicalize().unwrap_or(path);
                 lv.clipboard().set_text(&abs.display().to_string());
             }
@@ -1232,12 +1391,26 @@ pub(super) fn build_dir_tab(
         let tabs = open_tabs.clone();
         let ld = left_dir.clone();
         let rd = right_dir.clone();
+        let ll = left_label_override.clone();
+        let rl = right_label_override.clone();
         let st = settings.clone();
         action.connect_activate(move |_, _| {
             if let Some(raw) = get_row() {
                 let info = DirRowInfo::decode(&raw);
                 if !info.is_dir {
-                    open_file_diff(&nb, &info.rel_path, &tabs, &ld.borrow(), &rd.borrow(), &st);
+                    let labels: Vec<String> = [ll.borrow().clone(), rl.borrow().clone()]
+                        .into_iter()
+                        .flatten()
+                        .collect();
+                    open_file_diff(
+                        &nb,
+                        &info.rel_path,
+                        &tabs,
+                        &ld.borrow(),
+                        &rd.borrow(),
+                        &labels,
+                        &st,
+                    );
                 }
             }
         });
@@ -1322,16 +1495,14 @@ pub(super) fn build_dir_tab(
                         FileStatus::RightOnly => !is_left,
                         _ => true,
                     };
-                    ao.set_enabled(
-                        !is_dir && (status == FileStatus::Different || status == FileStatus::Same),
-                    );
+                    let is_diff_like =
+                        status == FileStatus::Different || status == FileStatus::Conflict;
+                    ao.set_enabled(!is_dir && (is_diff_like || status == FileStatus::Same));
                     al.set_enabled(
-                        exists_on_this_side
-                            && (status == FileStatus::RightOnly || status == FileStatus::Different),
+                        exists_on_this_side && (status == FileStatus::RightOnly || is_diff_like),
                     );
                     ar.set_enabled(
-                        exists_on_this_side
-                            && (status == FileStatus::LeftOnly || status == FileStatus::Different),
+                        exists_on_this_side && (status == FileStatus::LeftOnly || is_diff_like),
                     );
                     ad.set_enabled(exists_on_this_side);
                     ae.set_enabled(!is_dir && exists_on_this_side);
@@ -1353,6 +1524,8 @@ pub(super) fn build_dir_tab(
         let tabs = open_tabs.clone();
         let ld = left_dir.clone();
         let rd = right_dir.clone();
+        let ll = left_label_override.clone();
+        let rl = right_label_override.clone();
         let sel = dir_sel.clone();
         let st = settings.clone();
         Rc::new(move || {
@@ -1365,7 +1538,19 @@ pub(super) fn build_dir_tab(
                 if info.is_dir {
                     row.set_expanded(!row.is_expanded());
                 } else {
-                    open_file_diff(&nb, &info.rel_path, &tabs, &ld.borrow(), &rd.borrow(), &st);
+                    let labels: Vec<String> = [ll.borrow().clone(), rl.borrow().clone()]
+                        .into_iter()
+                        .flatten()
+                        .collect();
+                    open_file_diff(
+                        &nb,
+                        &info.rel_path,
+                        &tabs,
+                        &ld.borrow(),
+                        &rd.borrow(),
+                        &labels,
+                        &st,
+                    );
                 }
             }
         })
@@ -1472,20 +1657,24 @@ pub(super) fn build_dir_tab(
         },
     );
 
-    // Build title
-    let left_name = Path::new(left_dir.borrow().as_str())
-        .file_name()
-        .map_or_else(
-            || left_dir.borrow().clone(),
-            |n| n.to_string_lossy().into_owned(),
-        );
-    let right_name = Path::new(right_dir.borrow().as_str())
-        .file_name()
-        .map_or_else(
-            || right_dir.borrow().clone(),
-            |n| n.to_string_lossy().into_owned(),
-        );
-    let title = format!("{left_name} — {right_name}");
+    // Build title — prefer label overrides (e.g. patch mode) over raw dir names
+    let left_name = left_label_override.borrow().clone().unwrap_or_else(|| {
+        Path::new(left_dir.borrow().as_str())
+            .file_name()
+            .map_or_else(
+                || left_dir.borrow().clone(),
+                |n| n.to_string_lossy().into_owned(),
+            )
+    });
+    let right_name = right_label_override.borrow().clone().unwrap_or_else(|| {
+        Path::new(right_dir.borrow().as_str())
+            .file_name()
+            .map_or_else(
+                || right_dir.borrow().clone(),
+                |n| n.to_string_lossy().into_owned(),
+            )
+    });
+    let title = format!("{left_name} \u{2014} {right_name}");
 
     (dir_tab, dir_watcher, left_view, title)
 }
@@ -1501,6 +1690,7 @@ pub(super) fn open_dir_comparison_tab(
     let (dir_widget, dir_watcher, left_view, dir_title) = build_dir_tab(
         left_dir,
         right_dir,
+        &[],
         &[],
         Rc::clone(settings),
         notebook,
@@ -1551,14 +1741,32 @@ pub(super) fn build_dir_window(
     labels: &[String],
     settings: Rc<RefCell<Settings>>,
 ) {
+    build_dir_window_with_tooltips(app, left_dir, right_dir, labels, &[], settings);
+}
+
+pub(super) fn build_dir_window_with_tooltips(
+    app: &Application,
+    left_dir: std::path::PathBuf,
+    right_dir: std::path::PathBuf,
+    labels: &[String],
+    tooltip_dirs: &[String],
+    settings: Rc<RefCell<Settings>>,
+) {
     let AppWindow {
         window,
         notebook,
         open_tabs,
     } = build_app_window(app, &settings, 900, 600, true);
 
-    let (dir_tab, dir_watcher, left_view, title) =
-        build_dir_tab(left_dir, right_dir, labels, settings, &notebook, &open_tabs);
+    let (dir_tab, dir_watcher, left_view, title) = build_dir_tab(
+        left_dir,
+        right_dir,
+        labels,
+        tooltip_dirs,
+        settings,
+        &notebook,
+        &open_tabs,
+    );
     notebook.append_page(&dir_tab, Some(&Label::new(Some(&title))));
 
     window.connect_destroy(move |_| {
@@ -1655,6 +1863,26 @@ mod tests {
     }
 
     #[test]
+    fn encode_decode_conflict() {
+        let original = DirRowInfo {
+            status: FileStatus::Conflict,
+            name: "broken.rs".to_string(),
+            is_dir: false,
+            rel_path: "src/broken.rs".to_string(),
+            left_size: Some(100),
+            left_mtime: None,
+            right_size: Some(200),
+            right_mtime: None,
+        };
+        let encoded = original.encode();
+        let decoded = DirRowInfo::decode(&encoded);
+
+        assert_eq!(decoded.status, FileStatus::Conflict);
+        assert_eq!(decoded.name, "broken.rs");
+        assert_eq!(decoded.rel_path, "src/broken.rs");
+    }
+
+    #[test]
     fn decode_field_out_of_bounds() {
         // Should return empty string for missing fields via helper
         assert_eq!(DirRowInfo::get_field_text("a\x1fb", 5), "");
@@ -1686,6 +1914,7 @@ mod tests {
     fn file_status_codes() {
         assert_eq!(FileStatus::Same.code(), "S");
         assert_eq!(FileStatus::Different.code(), "D");
+        assert_eq!(FileStatus::Conflict.code(), "C");
         assert_eq!(FileStatus::LeftOnly.code(), "L");
         assert_eq!(FileStatus::RightOnly.code(), "R");
     }

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -180,9 +180,11 @@ fn scan_tree(
     rel: &str,
     dir_filters: &[String],
     hide_hidden: bool,
+    patch_mode: bool,
 ) -> (Vec<ScanEntry>, FileStatus) {
-    // Check for a conflicts marker file written by patch mode.
-    let conflicts = if rel.is_empty() {
+    // Only read the conflicts marker in patch mode to avoid misclassifying
+    // files when a real directory happens to contain `.mergers-conflicts`.
+    let conflicts = if patch_mode && rel.is_empty() {
         let marker = right_root.join(".mergers-conflicts");
         if let Ok(content) = fs::read_to_string(&marker) {
             content.lines().map(String::from).collect()
@@ -506,6 +508,8 @@ pub(super) fn build_dir_tab(
         Rc::new(RefCell::new(tooltip_dirs.first().cloned()));
     let right_tooltip_override: Rc<RefCell<Option<String>>> =
         Rc::new(RefCell::new(tooltip_dirs.get(1).cloned()));
+    // Patch mode: tooltip_dirs is non-empty only for patch comparisons
+    let patch_mode = !tooltip_dirs.is_empty();
     let left_dir = Rc::new(RefCell::new(
         std::fs::canonicalize(&left_dir)
             .unwrap_or(left_dir)
@@ -532,7 +536,7 @@ pub(super) fn build_dir_tab(
         let rs = root_store.clone();
         gtk4::glib::spawn_future_local(async move {
             let (entries, _) = gio::spawn_blocking(move || {
-                scan_tree(Path::new(&ld), Path::new(&rd), "", &filters, hide_hidden)
+                scan_tree(Path::new(&ld), Path::new(&rd), "", &filters, hide_hidden, patch_mode)
             })
             .await
             .unwrap();
@@ -931,6 +935,7 @@ pub(super) fn build_dir_tab(
                         "",
                         &filters,
                         hide_hidden,
+                        patch_mode,
                     )
                 })
                 .await

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -138,11 +138,11 @@ fn read_dir_entries(
             if hide_hidden && name.starts_with('.') {
                 continue;
             }
-            // Use entry.file_type() (lstat) for is_dir to avoid following
-            // symlinks to directories (prevents infinite recursion with cycles).
-            // Use fs::metadata (stat) for size/mtime to get real file data.
+            // Use lstat (file_type/symlink_metadata) consistently to avoid
+            // following symlinks to directories (prevents infinite recursion)
+            // and to get consistent size/mtime for symlinks-to-dirs.
             let is_dir = entry.file_type().ok().is_some_and(|ft| ft.is_dir());
-            let meta = fs::metadata(entry.path()).ok();
+            let meta = fs::symlink_metadata(entry.path()).ok();
             map.insert(
                 name,
                 DirMeta {
@@ -293,12 +293,12 @@ fn scan_tree_inner(
                         let rm = right_entries.get(*name);
                         // Fast path: different sizes means different content
                         if lm.and_then(|m| m.size) == rm.and_then(|m| m.size) {
-                            let lc = fs::read(left_dir.join(name)).unwrap_or_default();
-                            let rc = fs::read(right_dir.join(name)).unwrap_or_default();
-                            if lc == rc {
-                                FileStatus::Same
-                            } else {
-                                FileStatus::Different
+                            let lc = fs::read(left_dir.join(name));
+                            let rc = fs::read(right_dir.join(name));
+                            match (lc, rc) {
+                                (Ok(l), Ok(r)) if l == r => FileStatus::Same,
+                                // Read errors (e.g. symlink-to-dir) → treat as different
+                                _ => FileStatus::Different,
                             }
                         } else {
                             FileStatus::Different
@@ -1181,13 +1181,17 @@ pub(super) fn build_dir_tab(
             let lv2 = lv.clone();
             let base_dir: Option<String> = base_dir_override.clone();
             let do_apply = move || {
-                // Suppress file watcher during bulk operations
+                // Suppress file watcher during bulk operations.
+                // Mark the root dirs, then re-mark per file so the 600ms
+                // window extends across the entire operation.
                 mark_saving(Path::new(&ld_str));
                 mark_saving(Path::new(&rd_str));
                 let mut errors = Vec::new();
                 for (rel, status) in &actionable {
                     let left_p = Path::new(&ld_str).join(rel);
                     let right_p = Path::new(&rd_str).join(rel);
+                    mark_saving(Path::new(&ld_str));
+                    mark_saving(Path::new(&rd_str));
                     let is_patch = base_dir.is_some();
                     match status {
                         FileStatus::Different => {

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -269,8 +269,20 @@ fn scan_tree_inner(
         } else {
             children = Vec::new();
             status = match (in_left, in_right) {
-                (true, false) => FileStatus::LeftOnly,
-                (false, true) => FileStatus::RightOnly,
+                (true, false) => {
+                    if conflicts.contains(&child_rel) {
+                        FileStatus::Conflict
+                    } else {
+                        FileStatus::LeftOnly
+                    }
+                }
+                (false, true) => {
+                    if conflicts.contains(&child_rel) {
+                        FileStatus::Conflict
+                    } else {
+                        FileStatus::RightOnly
+                    }
+                }
                 (true, true) => {
                     let lm = left_entries.get(*name);
                     let rm = right_entries.get(*name);
@@ -1777,7 +1789,7 @@ pub(super) fn build_dir_window(
     labels: &[String],
     settings: Rc<RefCell<Settings>>,
 ) {
-    build_dir_window_with_tooltips(app, left_dir, right_dir, labels, &[], settings);
+    build_dir_window_with_tooltips(app, left_dir, right_dir, labels, &[], None, settings);
 }
 
 pub(super) fn build_dir_window_with_tooltips(
@@ -1786,6 +1798,7 @@ pub(super) fn build_dir_window_with_tooltips(
     right_dir: std::path::PathBuf,
     labels: &[String],
     tooltip_dirs: &[String],
+    on_destroy: Option<Box<dyn Fn() + 'static>>,
     settings: Rc<RefCell<Settings>>,
 ) {
     let AppWindow {
@@ -1808,6 +1821,12 @@ pub(super) fn build_dir_window_with_tooltips(
     window.connect_destroy(move |_| {
         dir_watcher.alive.set(false);
     });
+
+    // If a cleanup callback is provided (e.g. patch mode temp dir), run it on destroy
+    if let Some(on_destroy) = on_destroy {
+        window.connect_destroy(move |_| on_destroy());
+    }
+
     window.present();
     left_view.grab_focus();
 }

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -536,7 +536,14 @@ pub(super) fn build_dir_tab(
         let rs = root_store.clone();
         gtk4::glib::spawn_future_local(async move {
             let (entries, _) = gio::spawn_blocking(move || {
-                scan_tree(Path::new(&ld), Path::new(&rd), "", &filters, hide_hidden, patch_mode)
+                scan_tree(
+                    Path::new(&ld),
+                    Path::new(&rd),
+                    "",
+                    &filters,
+                    hide_hidden,
+                    patch_mode,
+                )
             })
             .await
             .unwrap();

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -1994,49 +1994,36 @@ mod tests {
     }
 
     // ── collect_actionable_files logic ──────────────────────────
+    //
+    // `collect_actionable_files` walks a GTK ListStore tree, which requires
+    // GTK main-thread init and can't be unit-tested directly. These tests
+    // verify the filtering predicate it uses (lines 111-116) and the
+    // non-patch LeftOnly exclusion (line 1174).
 
     #[test]
-    fn actionable_includes_different() {
-        assert!(matches!(
-            FileStatus::Different,
-            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
-        ));
+    fn actionable_status_filter() {
+        // Mirrors the match arms in collect_actionable_files
+        let statuses = [
+            (FileStatus::Different, true),
+            (FileStatus::RightOnly, true),
+            (FileStatus::LeftOnly, true),
+            (FileStatus::Conflict, false),
+            (FileStatus::Same, false),
+        ];
+        for (status, expected) in &statuses {
+            let is_actionable = matches!(
+                status,
+                FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+            );
+            assert_eq!(
+                is_actionable, *expected,
+                "FileStatus::{status:?} should be actionable={expected}"
+            );
+        }
     }
 
     #[test]
-    fn actionable_includes_right_only() {
-        assert!(matches!(
-            FileStatus::RightOnly,
-            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
-        ));
-    }
-
-    #[test]
-    fn actionable_includes_left_only() {
-        assert!(matches!(
-            FileStatus::LeftOnly,
-            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
-        ));
-    }
-
-    #[test]
-    fn actionable_excludes_conflict() {
-        assert!(!matches!(
-            FileStatus::Conflict,
-            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
-        ));
-    }
-
-    #[test]
-    fn actionable_excludes_same() {
-        assert!(!matches!(
-            FileStatus::Same,
-            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
-        ));
-    }
-
-    #[test]
-    fn actionable_filter_mixed_statuses() {
+    fn actionable_mixed_filter() {
         let entries = [
             ("a.rs", FileStatus::Different),
             ("b.rs", FileStatus::Same),
@@ -2055,6 +2042,21 @@ mod tests {
             .map(|(name, _)| *name)
             .collect();
         assert_eq!(result, vec!["a.rs", "d.rs", "e.rs"]);
+    }
+
+    #[test]
+    fn actionable_non_patch_excludes_left_only() {
+        // In non-patch mode, LeftOnly is filtered out after collection (line 1174)
+        let mut actionable = vec![
+            ("a.rs".to_string(), FileStatus::Different),
+            ("b.rs".to_string(), FileStatus::LeftOnly),
+            ("c.rs".to_string(), FileStatus::RightOnly),
+            ("d.rs".to_string(), FileStatus::LeftOnly),
+        ];
+        // Simulate the retain at line 1174
+        actionable.retain(|(_, s)| *s != FileStatus::LeftOnly);
+        let paths: Vec<&str> = actionable.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["a.rs", "c.rs"]);
     }
 
     // ── FileStatus ────────────────────────────────────────────────

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -138,10 +138,11 @@ fn read_dir_entries(
             if hide_hidden && name.starts_with('.') {
                 continue;
             }
-            // Use fs::metadata (follows symlinks) instead of entry.metadata()
-            // which is equivalent to lstat and returns symlink metadata.
+            // Use entry.file_type() (lstat) for is_dir to avoid following
+            // symlinks to directories (prevents infinite recursion with cycles).
+            // Use fs::metadata (stat) for size/mtime to get real file data.
+            let is_dir = entry.file_type().ok().is_some_and(|ft| ft.is_dir());
             let meta = fs::metadata(entry.path()).ok();
-            let is_dir = meta.as_ref().is_some_and(std::fs::Metadata::is_dir);
             map.insert(
                 name,
                 DirMeta {
@@ -1936,6 +1937,70 @@ mod tests {
 
         assert_eq!(decoded.name, "file with spaces.txt");
         assert_eq!(decoded.rel_path, "path/file with spaces.txt");
+    }
+
+    // ── collect_actionable_files logic ──────────────────────────
+
+    #[test]
+    fn actionable_includes_different() {
+        assert!(matches!(
+            FileStatus::Different,
+            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+        ));
+    }
+
+    #[test]
+    fn actionable_includes_right_only() {
+        assert!(matches!(
+            FileStatus::RightOnly,
+            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+        ));
+    }
+
+    #[test]
+    fn actionable_includes_left_only() {
+        assert!(matches!(
+            FileStatus::LeftOnly,
+            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+        ));
+    }
+
+    #[test]
+    fn actionable_excludes_conflict() {
+        assert!(!matches!(
+            FileStatus::Conflict,
+            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+        ));
+    }
+
+    #[test]
+    fn actionable_excludes_same() {
+        assert!(!matches!(
+            FileStatus::Same,
+            FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+        ));
+    }
+
+    #[test]
+    fn actionable_filter_mixed_statuses() {
+        let entries = [
+            ("a.rs", FileStatus::Different),
+            ("b.rs", FileStatus::Same),
+            ("c.rs", FileStatus::Conflict),
+            ("d.rs", FileStatus::RightOnly),
+            ("e.rs", FileStatus::LeftOnly),
+        ];
+        let result: Vec<&str> = entries
+            .iter()
+            .filter(|(_, s)| {
+                matches!(
+                    s,
+                    FileStatus::Different | FileStatus::RightOnly | FileStatus::LeftOnly
+                )
+            })
+            .map(|(name, _)| *name)
+            .collect();
+        assert_eq!(result, vec!["a.rs", "d.rs", "e.rs"]);
     }
 
     // ── FileStatus ────────────────────────────────────────────────

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -502,8 +502,10 @@ pub(super) fn build_dir_tab(
         Rc::new(RefCell::new(labels.first().cloned()));
     let right_label_override: Rc<RefCell<Option<String>>> =
         Rc::new(RefCell::new(labels.get(1).cloned()));
-    let left_tooltip_override: Option<String> = tooltip_dirs.first().cloned();
-    let right_tooltip_override: Option<String> = tooltip_dirs.get(1).cloned();
+    let left_tooltip_override: Rc<RefCell<Option<String>>> =
+        Rc::new(RefCell::new(tooltip_dirs.first().cloned()));
+    let right_tooltip_override: Rc<RefCell<Option<String>>> =
+        Rc::new(RefCell::new(tooltip_dirs.get(1).cloned()));
     let left_dir = Rc::new(RefCell::new(
         std::fs::canonicalize(&left_dir)
             .unwrap_or(left_dir)
@@ -758,7 +760,8 @@ pub(super) fn build_dir_tab(
     let left_header = Label::new(Some(&left_header_text));
     {
         let ld = left_dir.borrow();
-        let left_tip = left_tooltip_override.as_deref().unwrap_or(&ld);
+        let lto = left_tooltip_override.borrow();
+        let left_tip: &str = lto.as_ref().map_or(&*ld, String::as_str);
         left_header.set_tooltip_text(Some(left_tip));
     }
     left_header.set_ellipsize(gtk4::pango::EllipsizeMode::Start);
@@ -787,7 +790,8 @@ pub(super) fn build_dir_tab(
     let right_header = Label::new(Some(&right_header_text));
     {
         let rd = right_dir.borrow();
-        let right_tip = right_tooltip_override.as_deref().unwrap_or(&rd);
+        let rto = right_tooltip_override.borrow();
+        let right_tip: &str = rto.as_ref().map_or(&*rd, String::as_str);
         right_header.set_tooltip_text(Some(right_tip));
     }
     right_header.set_ellipsize(gtk4::pango::EllipsizeMode::Start);
@@ -1017,9 +1021,13 @@ pub(super) fn build_dir_tab(
         let rd = right_dir.clone();
         let ll = left_label_override.clone();
         let rl = right_label_override.clone();
+        let lto = left_tooltip_override.clone();
+        let rto = right_tooltip_override.clone();
         let reload = reload_dir.clone();
         let lh = left_header.clone();
         let rh = right_header.clone();
+        let aab = apply_all_btn.clone();
+        let swapped = Rc::new(Cell::new(false));
         dir_swap_btn.connect_clicked(move |btn| {
             let tmp = ld.borrow().clone();
             (*ld.borrow_mut()).clone_from(&rd.borrow());
@@ -1027,18 +1035,38 @@ pub(super) fn build_dir_tab(
             let tmp_label = ll.borrow().clone();
             (*ll.borrow_mut()).clone_from(&rl.borrow());
             *rl.borrow_mut() = tmp_label;
+            let tmp_tip = lto.borrow().clone();
+            (*lto.borrow_mut()).clone_from(&rto.borrow());
+            *rto.borrow_mut() = tmp_tip;
             let left_text = match *ll.borrow() {
                 Some(ref l) => l.clone(),
                 None => shortened_path(Path::new(&*ld.borrow())),
             };
             lh.set_text(&left_text);
-            lh.set_tooltip_text(Some(&*ld.borrow()));
+            {
+                let ld_ref = ld.borrow();
+                let lto_ref = lto.borrow();
+                let left_tip: &str = lto_ref.as_ref().map_or(&*ld_ref, String::as_str);
+                lh.set_tooltip_text(Some(left_tip));
+            }
             let right_text = match *rl.borrow() {
                 Some(ref l) => l.clone(),
                 None => shortened_path(Path::new(&*rd.borrow())),
             };
             rh.set_text(&right_text);
-            rh.set_tooltip_text(Some(&*rd.borrow()));
+            {
+                let rd_ref = rd.borrow();
+                let rto_ref = rto.borrow();
+                let right_tip: &str = rto_ref.as_ref().map_or(&*rd_ref, String::as_str);
+                rh.set_tooltip_text(Some(right_tip));
+            }
+            // In patch mode, disable apply-all when swapped (directions get confused)
+            let is_patch = lto.borrow().is_some() || rto.borrow().is_some();
+            if is_patch {
+                let now_swapped = !swapped.get();
+                swapped.set(now_swapped);
+                aab.set_sensitive(!now_swapped);
+            }
             // Update window title
             if let Some(win) = find_window(btn) {
                 let ln = Path::new(ld.borrow().as_str())
@@ -1134,7 +1162,7 @@ pub(super) fn build_dir_tab(
         let rd = right_dir.clone();
         let reload = reload_dir.clone();
         let lv = left_view.clone();
-        let base_dir_override: Option<String> = left_tooltip_override.clone();
+        let base_dir_override: Option<String> = left_tooltip_override.borrow().clone();
         apply_all_btn.connect_clicked(move |_| {
             let ld_str = ld.borrow().clone();
             let rd_str = rd.borrow().clone();

--- a/src/ui/dir_window.rs
+++ b/src/ui/dir_window.rs
@@ -1119,6 +1119,7 @@ pub(super) fn build_dir_tab(
         let rd = right_dir.clone();
         let reload = reload_dir.clone();
         let lv = left_view.clone();
+        let base_dir_override: Option<String> = left_tooltip_override.clone();
         apply_all_btn.connect_clicked(move |_| {
             let ld_str = ld.borrow().clone();
             let rd_str = rd.borrow().clone();
@@ -1130,6 +1131,7 @@ pub(super) fn build_dir_tab(
             let count = actionable.len();
             let reload = reload.clone();
             let lv2 = lv.clone();
+            let base_dir: Option<String> = base_dir_override.clone();
             let do_apply = move || {
                 // Suppress file watcher during bulk operations
                 mark_saving(Path::new(&ld_str));
@@ -1139,8 +1141,8 @@ pub(super) fn build_dir_tab(
                     let left_p = Path::new(&ld_str).join(rel);
                     let right_p = Path::new(&rd_str).join(rel);
                     match status {
-                        FileStatus::Different | FileStatus::RightOnly => {
-                            // Copy right → left (modified or new file)
+                        FileStatus::Different => {
+                            // Copy right → left (modified file; symlink follows to original)
                             if let Some(parent) = left_p.parent() {
                                 let _ = fs::create_dir_all(parent);
                             }
@@ -1152,8 +1154,32 @@ pub(super) fn build_dir_tab(
                             let _ = fs::remove_file(&left_p);
                             let _ = fs::remove_file(&right_p);
                         }
+                        FileStatus::RightOnly => {
+                            // New file — copy right to the real base dir if in patch mode,
+                            // otherwise copy to the left dir.
+                            let target = if let Some(ref base) = base_dir {
+                                PathBuf::from(base).join(rel)
+                            } else {
+                                left_p.clone()
+                            };
+                            if let Some(parent) = target.parent() {
+                                let _ = fs::create_dir_all(parent);
+                            }
+                            if let Err(e) = copy_path_recursive(&right_p, &target) {
+                                errors.push(format!("{rel}: {e}"));
+                                continue;
+                            }
+                            // Remove temp sides so they vanish from the scan
+                            let _ = fs::remove_file(&left_p);
+                            let _ = fs::remove_file(&right_p);
+                        }
                         FileStatus::LeftOnly => {
-                            // Deleted file — remove from left
+                            // Deleted file — remove the real file (resolve symlink in patch mode)
+                            if base_dir.is_some() {
+                                // In patch mode, left_p is a symlink; resolve to original
+                                let real_path = fs::canonicalize(&left_p).unwrap_or(left_p.clone());
+                                let _ = fs::remove_file(&real_path);
+                            }
                             let _ = fs::remove_file(&left_p);
                         }
                         FileStatus::Conflict | FileStatus::Same => {}

--- a/src/ui/merge_state.rs
+++ b/src/ui/merge_state.rs
@@ -319,4 +319,65 @@ mod tests {
     fn conflict_at_cursor_empty() {
         assert_eq!(conflict_at_cursor("", 0), None);
     }
+
+    // ── find_conflict_blocks edge cases ──────────────────────────────
+
+    #[test]
+    fn conflict_blocks_unmatched_open() {
+        // <<<<<<< without >>>>>>> — should produce no blocks
+        let text = "before\n<<<<<<< HEAD\nours\n=======\ntheirs\n";
+        let blocks = find_conflict_blocks(text);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn conflict_blocks_unmatched_close() {
+        // >>>>>>> without <<<<<<< — should produce no blocks
+        let text = "before\nsome text\n>>>>>>> branch\nafter\n";
+        let blocks = find_conflict_blocks(text);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn conflict_blocks_adjacent() {
+        // Two blocks right next to each other
+        let text = "<<<<<<< a\nours\n>>>>>>> b\n<<<<<<< c\ntheirs\n>>>>>>> d\n";
+        let blocks = find_conflict_blocks(text);
+        assert_eq!(blocks, vec![(0, 2), (3, 5)]);
+    }
+
+    #[test]
+    fn conflict_blocks_nested_open_takes_last() {
+        // Second <<<<<<< overwrites the first open (only innermost block matched)
+        let text = "<<<<<<< first\nstuff\n<<<<<<< second\nmore\n>>>>>>> end\n";
+        let blocks = find_conflict_blocks(text);
+        assert_eq!(blocks, vec![(2, 4)]);
+    }
+
+    // ── conflict_at_cursor_fast edge cases ───────────────────────────
+
+    #[test]
+    fn conflict_at_cursor_fast_empty_blocks() {
+        assert_eq!(conflict_at_cursor_fast(&[], 0), None);
+        assert_eq!(conflict_at_cursor_fast(&[], 100), None);
+    }
+
+    #[test]
+    fn conflict_at_cursor_fast_exactly_on_boundaries() {
+        let blocks = vec![(5, 10), (20, 25)];
+        assert_eq!(conflict_at_cursor_fast(&blocks, 4), None);
+        assert_eq!(conflict_at_cursor_fast(&blocks, 5), Some(5)); // open marker
+        assert_eq!(conflict_at_cursor_fast(&blocks, 10), Some(5)); // close marker
+        assert_eq!(conflict_at_cursor_fast(&blocks, 11), None); // just after
+        assert_eq!(conflict_at_cursor_fast(&blocks, 20), Some(20));
+        assert_eq!(conflict_at_cursor_fast(&blocks, 25), Some(20));
+        assert_eq!(conflict_at_cursor_fast(&blocks, 26), None);
+    }
+
+    #[test]
+    fn conflict_at_cursor_fast_between_blocks() {
+        let blocks = vec![(0, 3), (10, 15)];
+        assert_eq!(conflict_at_cursor_fast(&blocks, 5), None);
+        assert_eq!(conflict_at_cursor_fast(&blocks, 9), None);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -88,6 +88,7 @@ mod file_window;
 #[doc(hidden)]
 pub mod merge_state;
 mod merge_view;
+mod patch_window;
 mod preferences;
 mod vcs_window;
 mod welcome;
@@ -97,6 +98,7 @@ use diff_view::*;
 use dir_window::*;
 use file_window::*;
 use merge_view::*;
+use patch_window::*;
 use preferences::*;
 use vcs_window::*;
 use welcome::*;
@@ -247,6 +249,11 @@ pub fn build_ui(application: &Application, mode: CompareMode) {
                 right,
                 labels,
             } => build_merge_window(app, left, middle, right, &labels, &settings),
+            CompareMode::Patch {
+                base,
+                patch,
+                labels,
+            } => build_patch_window(app, base, patch, &labels, &settings),
             CompareMode::Vcs { dir } => build_vcs_window(app, dir, settings),
             CompareMode::Welcome => build_welcome_window(app, settings),
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -89,6 +89,7 @@ mod file_window;
 pub mod merge_state;
 mod merge_view;
 mod patch_window;
+pub use patch_window::cleanup_patch_temp_dirs;
 mod preferences;
 mod vcs_window;
 mod welcome;

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -1,0 +1,12 @@
+#[allow(clippy::wildcard_imports)]
+use super::*;
+
+pub(super) fn build_patch_window(
+    _app: &Application,
+    _base: PathBuf,
+    _patch: PathBuf,
+    _labels: &[String],
+    _settings: &Rc<RefCell<Settings>>,
+) {
+    todo!("patch window implementation")
+}

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -62,6 +62,12 @@ pub(super) fn build_patch_window(
         show_patch_error(app, &format!("Cannot create temp directory: {e}"));
         return;
     }
+    // Restrict permissions to owner-only (0o700)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp_dir, fs::Permissions::from_mode(0o700));
+    }
 
     // Register for cleanup on shutdown / signal
     if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
@@ -90,15 +96,20 @@ pub(super) fn build_patch_window(
 }
 
 fn show_patch_error(app: &Application, message: &str) {
-    // Create a temporary window to host the error dialog, then show it.
-    let window = ApplicationWindow::builder()
-        .application(app)
-        .title("mergers")
-        .default_width(400)
-        .default_height(100)
-        .build();
-    window.present();
-    show_error_dialog(&window, message);
+    if let Some(win) = app.active_window().and_downcast::<ApplicationWindow>() {
+        show_error_dialog(&win, message);
+    } else {
+        // No window yet — create a transient one that closes after the dialog
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("mergers")
+            .default_width(400)
+            .default_height(100)
+            .build();
+        window.present();
+        show_error_dialog(&window, message);
+        window.close();
+    }
 }
 
 fn build_single_file_patch(

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -286,8 +286,8 @@ fn build_multi_file_patch(
             );
             continue;
         };
-        let left_path = left_dir.join(rel_path);
-        let right_path = right_dir.join(rel_path);
+        let left_path = left_dir.join(&rel_path);
+        let right_path = right_dir.join(&rel_path);
 
         // Ensure parent dirs exist in the right (patched) tree.
         // Left tree uses symlinks, so only the right tree needs real dirs.
@@ -301,7 +301,7 @@ fn build_multi_file_patch(
         match fp.kind {
             PatchKind::Deleted => {
                 // Symlink original on left, nothing on right → shows as LeftOnly
-                let orig_path = base.join(rel_path);
+                let orig_path = base.join(&rel_path);
                 if orig_path.exists() {
                     if let Some(parent) = left_path.parent() {
                         fs::create_dir_all(parent).ok();
@@ -346,7 +346,7 @@ fn build_multi_file_patch(
                 }
             }
             PatchKind::Modified => {
-                let orig_path = base.join(rel_path);
+                let orig_path = base.join(&rel_path);
                 let original = match fs::read_to_string(&orig_path) {
                     Ok(c) => c,
                     Err(e) => {

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -337,7 +337,13 @@ fn build_multi_file_patch(
                     }
                     p
                 };
-                fs::write(&right_path, patched).ok();
+                if let Err(e) = fs::write(&right_path, patched) {
+                    eprintln!(
+                        "Warning: failed to write patched file {}: {e}",
+                        right_path.display()
+                    );
+                    conflict_paths.push(rel_path.to_string());
+                }
             }
             PatchKind::Modified => {
                 let orig_path = base.join(rel_path);
@@ -376,7 +382,13 @@ fn build_multi_file_patch(
                     }
                 };
 
-                fs::write(&right_path, patched).ok();
+                if let Err(e) = fs::write(&right_path, patched) {
+                    eprintln!(
+                        "Warning: failed to write patched file {}: {e}",
+                        right_path.display()
+                    );
+                    conflict_paths.push(rel_path.to_string());
+                }
             }
         }
     }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -241,10 +241,13 @@ fn build_single_file_patch(
         });
     }
 
-    // Clean up temp dir on destroy
+    // Clean up temp dir on destroy and remove from global registry
     let tmp_dir_owned = tmp_dir.to_path_buf();
     window.connect_destroy(move |_| {
         let _ = fs::remove_dir_all(&tmp_dir_owned);
+        if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
+            dirs.retain(|d| *d != tmp_dir_owned);
+        }
     });
 
     window.present();
@@ -336,12 +339,14 @@ fn build_multi_file_patch(
             }
             PatchKind::Added => {
                 // Nothing on left, patched on right → shows as RightOnly
-                let patched = match apply_hunks("", &fp.hunks) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        eprintln!("Warning: failed to apply patch for new file {rel_path}: {e}");
-                        String::new()
+                let patched = if let Ok(p) = apply_hunks("", &fp.hunks) {
+                    p
+                } else {
+                    let p = apply_hunks_best_effort("", &fp.hunks);
+                    if p.contains("<<<<<<< original") {
+                        conflict_paths.push(rel_path.to_string());
                     }
+                    p
                 };
                 fs::write(&right_path, patched).ok();
             }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -49,25 +49,14 @@ pub(super) fn build_patch_window(
         return;
     }
 
-    // Create temp directory with a random name to prevent symlink attacks
-    let tmp_dir = std::env::temp_dir().join(format!(
-        "mergers-patch-{}-{:016x}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_nanos() as u64)
-    ));
-    // Use create_dir (not create_dir_all) so it fails if the path already exists
-    if let Err(e) = fs::create_dir(&tmp_dir) {
-        show_patch_error(app, &format!("Cannot create temp directory: {e}"));
-        return;
-    }
-    // Restrict permissions to owner-only (0o700)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&tmp_dir, fs::Permissions::from_mode(0o700));
-    }
+    // Create temp directory with secure permissions (0o700, collision-resistant)
+    let tmp_dir = match tempfile::tempdir() {
+        Ok(d) => d.keep(),
+        Err(e) => {
+            show_patch_error(app, &format!("Cannot create temp directory: {e}"));
+            return;
+        }
+    };
 
     if base.is_file() {
         build_single_file_patch(

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -118,9 +118,9 @@ fn build_single_file_patch(
         }
     };
 
-    // Find the patch entry that matches the base filename, or fall back to
-    // the first entry for single-file patches. This prevents silently applying
-    // an unrelated file's hunks when the patch targets multiple files.
+    // Find the patch entry that matches the base filename. Reject ambiguous
+    // matches (multiple entries with the same basename) to avoid silently
+    // applying the wrong file's hunks.
     let base_name = base
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -128,22 +128,33 @@ fn build_single_file_patch(
     let fp = if file_patches.len() == 1 {
         &file_patches[0]
     } else {
-        let Some(found) = file_patches.iter().find(|fp| {
-            std::path::Path::new(&fp.original_path)
-                .file_name()
-                .is_some_and(|n| n.to_string_lossy() == base_name)
-        }) else {
-            show_patch_error(
-                app,
-                &format!(
+        let matches: Vec<_> = file_patches
+            .iter()
+            .filter(|fp| {
+                std::path::Path::new(&fp.original_path)
+                    .file_name()
+                    .is_some_and(|n| n.to_string_lossy() == base_name)
+            })
+            .collect();
+        if matches.len() == 1 {
+            matches[0]
+        } else {
+            let msg = if matches.is_empty() {
+                format!(
                     "Patch does not contain an entry for '{base_name}'. \
                      Use directory mode for multi-file patches.",
-                ),
-            );
+                )
+            } else {
+                format!(
+                    "Patch contains {} entries matching '{base_name}'. \
+                     Use directory mode for multi-file patches.",
+                    matches.len()
+                )
+            };
+            show_patch_error(app, &msg);
             let _ = fs::remove_dir_all(tmp_dir);
             return;
-        };
-        found
+        }
     };
     let patched = match apply_hunks(&original, &fp.hunks) {
         Ok(p) => p,
@@ -296,7 +307,19 @@ fn build_multi_file_patch(
                     #[cfg(windows)]
                     fs::copy(&orig_path, &left_path).ok();
                 } else {
+                    // Base file missing — write error to both sides so the entry
+                    // appears as a Modified/conflict row, not invisibly absent.
                     eprintln!("Warning: base file not found for deleted entry: {rel_path}");
+                    let msg = format!("[Base file not found: {rel_path}]\n");
+                    if let Some(parent) = left_path.parent() {
+                        fs::create_dir_all(parent).ok();
+                    }
+                    fs::write(&left_path, &msg).ok();
+                    if let Some(parent) = right_path.parent() {
+                        fs::create_dir_all(parent).ok();
+                    }
+                    fs::write(&right_path, &msg).ok();
+                    conflict_paths.push(rel_path.to_string());
                 }
             }
             PatchKind::Added => {

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -238,15 +238,12 @@ fn build_multi_file_patch(
     let mut conflict_paths: Vec<String> = Vec::new();
 
     for fp in file_patches {
-        let rel_path = match sanitize_patch_path(&fp.original_path) {
-            Some(p) => p,
-            None => {
-                eprintln!(
-                    "Warning: skipping unsafe patch path: {:?}",
-                    fp.original_path
-                );
-                continue;
-            }
+        let Some(rel_path) = sanitize_patch_path(&fp.original_path) else {
+            eprintln!(
+                "Warning: skipping unsafe patch path: {:?}",
+                fp.original_path
+            );
+            continue;
         };
         let left_path = left_dir.join(rel_path);
         let right_path = right_dir.join(rel_path);

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -69,11 +69,6 @@ pub(super) fn build_patch_window(
         let _ = fs::set_permissions(&tmp_dir, fs::Permissions::from_mode(0o700));
     }
 
-    // Register for cleanup on shutdown / signal
-    if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
-        dirs.push(tmp_dir.clone());
-    }
-
     if base.is_file() {
         build_single_file_patch(
             app,
@@ -239,6 +234,11 @@ fn build_single_file_patch(
                 save: dv.right_save.clone(),
             },
         });
+    }
+
+    // Register for cleanup on shutdown / signal (only after successful creation)
+    if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
+        dirs.push(tmp_dir.to_path_buf());
     }
 
     // Clean up temp dir on destroy and remove from global registry
@@ -419,6 +419,20 @@ fn build_multi_file_patch(
     // Only the left side gets overridden — the right side is generated temp content.
     let tooltip_dirs = vec![base.display().to_string()];
 
+    // Register for cleanup on shutdown / signal (only after successful creation)
+    if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
+        dirs.push(tmp_dir.to_path_buf());
+    }
+
+    // Clean up temp dir and unregister on window destroy
+    let tmp_owned = tmp_dir.to_path_buf();
+    let on_destroy: Box<dyn Fn() + 'static> = Box::new(move || {
+        let _ = fs::remove_dir_all(&tmp_owned);
+        if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
+            dirs.retain(|d| *d != tmp_owned);
+        }
+    });
+
     // Delegate to the existing directory comparison window
     build_dir_window_with_tooltips(
         app,
@@ -426,6 +440,7 @@ fn build_multi_file_patch(
         right_dir,
         &patch_labels,
         &tooltip_dirs,
+        Some(on_destroy),
         Rc::clone(settings),
     );
 }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
-use crate::patch::{apply_hunks, apply_hunks_best_effort, parse_patch};
+use crate::patch::{apply_hunks, apply_hunks_best_effort, parse_patch, sanitize_patch_path};
 
 use std::sync::Mutex;
 
@@ -48,9 +48,16 @@ pub(super) fn build_patch_window(
         return;
     }
 
-    // Create temp directory with a unique name
-    let tmp_dir = std::env::temp_dir().join(format!("mergers-patch-{}", std::process::id()));
-    if let Err(e) = fs::create_dir_all(&tmp_dir) {
+    // Create temp directory with a random name to prevent symlink attacks
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "mergers-patch-{}-{:016x}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos() as u64)
+    ));
+    // Use create_dir (not create_dir_all) so it fails if the path already exists
+    if let Err(e) = fs::create_dir(&tmp_dir) {
         show_patch_error(app, &format!("Cannot create temp directory: {e}"));
         return;
     }
@@ -217,13 +224,30 @@ fn build_multi_file_patch(
     // "right" has the patched versions. This avoids scanning the entire base tree.
     let left_dir = tmp_dir.join("left");
     let right_dir = tmp_dir.join("right");
-    fs::create_dir_all(&left_dir).ok();
-    fs::create_dir_all(&right_dir).ok();
+    if let Err(e) = fs::create_dir(&left_dir) {
+        show_patch_error(app, &format!("Cannot create temp directory: {e}"));
+        let _ = fs::remove_dir_all(tmp_dir);
+        return;
+    }
+    if let Err(e) = fs::create_dir(&right_dir) {
+        show_patch_error(app, &format!("Cannot create temp directory: {e}"));
+        let _ = fs::remove_dir_all(tmp_dir);
+        return;
+    }
 
     let mut conflict_paths: Vec<String> = Vec::new();
 
     for fp in file_patches {
-        let rel_path = &fp.original_path;
+        let rel_path = match sanitize_patch_path(&fp.original_path) {
+            Some(p) => p,
+            None => {
+                eprintln!(
+                    "Warning: skipping unsafe patch path: {:?}",
+                    fp.original_path
+                );
+                continue;
+            }
+        };
         let left_path = left_dir.join(rel_path);
         let right_path = right_dir.join(rel_path);
 
@@ -286,7 +310,7 @@ fn build_multi_file_patch(
                     Ok(p) => p,
                     Err(e) => {
                         eprintln!("Warning: failed to apply patch cleanly to {rel_path}: {e}");
-                        conflict_paths.push(rel_path.clone());
+                        conflict_paths.push(rel_path.to_string());
                         apply_hunks_best_effort(&original, &fp.hunks)
                     }
                 };

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -323,7 +323,7 @@ fn build_multi_file_patch(
                         fs::create_dir_all(parent).ok();
                     }
                     fs::write(&right_path, &msg).ok();
-                    conflict_paths.push(rel_path.to_string());
+                    conflict_paths.push(rel_path.clone());
                 }
             }
             PatchKind::Added => {
@@ -333,7 +333,7 @@ fn build_multi_file_patch(
                 } else {
                     let p = apply_hunks_best_effort("", &fp.hunks);
                     if p.contains("<<<<<<< original") {
-                        conflict_paths.push(rel_path.to_string());
+                        conflict_paths.push(rel_path.clone());
                     }
                     p
                 };
@@ -342,7 +342,7 @@ fn build_multi_file_patch(
                         "Warning: failed to write patched file {}: {e}",
                         right_path.display()
                     );
-                    conflict_paths.push(rel_path.to_string());
+                    conflict_paths.push(rel_path.clone());
                 }
             }
             PatchKind::Modified => {
@@ -359,7 +359,7 @@ fn build_multi_file_patch(
                         }
                         fs::write(&left_path, &msg).ok();
                         fs::write(&right_path, &msg).ok();
-                        conflict_paths.push(rel_path.to_string());
+                        conflict_paths.push(rel_path.clone());
                         continue;
                     }
                 };
@@ -377,7 +377,7 @@ fn build_multi_file_patch(
                     Ok(p) => p,
                     Err(e) => {
                         eprintln!("Warning: failed to apply patch cleanly to {rel_path}: {e}");
-                        conflict_paths.push(rel_path.to_string());
+                        conflict_paths.push(rel_path.clone());
                         apply_hunks_best_effort(&original, &fp.hunks)
                     }
                 };
@@ -387,7 +387,7 @@ fn build_multi_file_patch(
                         "Warning: failed to write patched file {}: {e}",
                         right_path.display()
                     );
-                    conflict_paths.push(rel_path.to_string());
+                    conflict_paths.push(rel_path.clone());
                 }
             }
         }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -52,15 +52,7 @@ pub(super) fn build_patch_window(
             settings,
         );
     } else if base.is_dir() {
-        build_multi_file_patch(
-            app,
-            &base,
-            &file_patches,
-            &patch_path,
-            &tmp_dir,
-            labels,
-            settings,
-        );
+        build_multi_file_patch(app, &base, &file_patches, &tmp_dir, labels, settings);
     } else {
         show_patch_error(
             app,
@@ -189,120 +181,99 @@ fn build_single_file_patch(
     });
 }
 
-#[allow(clippy::too_many_arguments)]
 fn build_multi_file_patch(
     app: &Application,
     base: &Path,
     file_patches: &[crate::patch::FilePatch],
-    patch_path: &Path,
     tmp_dir: &Path,
     labels: &[String],
     settings: &Rc<RefCell<Settings>>,
 ) {
-    let patch_filename = patch_path
-        .file_name()
-        .map_or_else(|| "patch".to_string(), |n| n.to_string_lossy().into_owned());
-    let title = format!("mergers \u{2014} {patch_filename}");
+    use crate::patch::PatchKind;
 
-    let AppWindow {
-        window,
-        notebook,
-        open_tabs,
-    } = build_app_window(app, settings, 900, 600, false);
-    window.set_title(Some(&title));
+    // Canonicalize base so symlinks use absolute paths
+    let base = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
 
-    let mut has_tabs = false;
+    // Two temp dirs: "left" has only the originals mentioned in the patch,
+    // "right" has the patched versions. This avoids scanning the entire base tree.
+    let left_dir = tmp_dir.join("left");
+    let right_dir = tmp_dir.join("right");
+    fs::create_dir_all(&left_dir).ok();
+    fs::create_dir_all(&right_dir).ok();
 
     for fp in file_patches {
         let rel_path = &fp.original_path;
-        let orig_path = base.join(rel_path);
+        let left_path = left_dir.join(rel_path);
+        let right_path = right_dir.join(rel_path);
 
-        let original = match fs::read_to_string(&orig_path) {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("Warning: cannot read {}: {e}", orig_path.display());
-                continue;
-            }
-        };
-
-        let patched = match apply_hunks(&original, &fp.hunks) {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!("Warning: failed to apply patch to {rel_path}: {e}");
-                original.clone()
-            }
-        };
-
-        // Write patched content — preserve subdirectory structure in temp dir
-        let tmp_path = tmp_dir.join(rel_path);
-        if let Some(parent) = tmp_path.parent()
+        // Ensure parent dirs exist in the right (patched) tree.
+        // Left tree uses symlinks, so only the right tree needs real dirs.
+        if let Some(parent) = right_path.parent()
             && let Err(e) = fs::create_dir_all(parent)
         {
             eprintln!("Warning: cannot create temp dir for {rel_path}: {e}");
             continue;
         }
-        if let Err(e) = fs::write(&tmp_path, &patched) {
-            eprintln!("Warning: cannot write temp file for {rel_path}: {e}");
-            continue;
+
+        match fp.kind {
+            PatchKind::Deleted => {
+                // Symlink original on left, nothing on right → shows as LeftOnly
+                let orig_path = base.join(rel_path);
+                if orig_path.exists() {
+                    if let Some(parent) = left_path.parent() {
+                        fs::create_dir_all(parent).ok();
+                    }
+                    #[cfg(unix)]
+                    std::os::unix::fs::symlink(&orig_path, &left_path).ok();
+                    #[cfg(windows)]
+                    fs::copy(&orig_path, &left_path).ok();
+                }
+            }
+            PatchKind::Added => {
+                // Nothing on left, patched on right → shows as RightOnly
+                let patched = match apply_hunks("", &fp.hunks) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("Warning: failed to apply patch for new file {rel_path}: {e}");
+                        String::new()
+                    }
+                };
+                fs::write(&right_path, patched).ok();
+            }
+            PatchKind::Modified => {
+                let orig_path = base.join(rel_path);
+                let original = match fs::read_to_string(&orig_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Warning: cannot read {}: {e}", orig_path.display());
+                        fs::write(&right_path, "").ok();
+                        continue;
+                    }
+                };
+
+                // Symlink original to left tree — saves write back through symlink
+                if let Some(parent) = left_path.parent() {
+                    fs::create_dir_all(parent).ok();
+                }
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(&orig_path, &left_path).ok();
+                #[cfg(windows)]
+                fs::copy(&orig_path, &left_path).ok();
+
+                let patched = match apply_hunks(&original, &fp.hunks) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("Warning: failed to apply patch to {rel_path}: {e}");
+                        fs::write(&right_path, "").ok();
+                        continue;
+                    }
+                };
+
+                fs::write(&right_path, patched).ok();
+            }
         }
-
-        let left_label = labels.first().cloned().unwrap_or_else(|| rel_path.clone());
-        let right_label = labels
-            .get(1)
-            .cloned()
-            .unwrap_or_else(|| format!("{rel_path} (patched)"));
-        let diff_labels = vec![left_label, right_label];
-
-        let dv = build_diff_view(&orig_path, &tmp_path, &diff_labels, settings);
-
-        // Right pane is read-only (patched output)
-        dv.right_save.set_sensitive(false);
-        dv.right_save.set_visible(false);
-
-        dv.widget
-            .insert_action_group("diff", Some(&dv.action_group));
-
-        let tab_title = rel_path.clone();
-        notebook.append_page(&dv.widget, Some(&Label::new(Some(&tab_title))));
-
-        // Register tab
-        {
-            let tab_id = NEXT_TAB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            open_tabs.borrow_mut().push(FileTab::Diff {
-                id: tab_id,
-                rel_path: tab_title,
-                widget: dv.widget.clone(),
-                left: PaneInfo {
-                    path: dv.left_tab_path.clone(),
-                    buf: dv.left_buf.clone(),
-                    save: dv.left_save.clone(),
-                },
-                right: PaneInfo {
-                    path: dv.right_tab_path.clone(),
-                    buf: dv.right_buf.clone(),
-                    save: dv.right_save.clone(),
-                },
-            });
-        }
-
-        has_tabs = true;
     }
 
-    if !has_tabs {
-        show_error_dialog(
-            &window,
-            "No files from the patch could be applied to the base directory",
-        );
-        let _ = fs::remove_dir_all(tmp_dir);
-        window.close();
-        return;
-    }
-
-    // Clean up temp dir on destroy
-    let tmp_dir_owned = tmp_dir.to_path_buf();
-    window.connect_destroy(move |_| {
-        let _ = fs::remove_dir_all(&tmp_dir_owned);
-    });
-
-    window.present();
+    // Delegate to the existing directory comparison window
+    build_dir_window(app, left_dir, right_dir, labels, Rc::clone(settings));
 }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -1,6 +1,20 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
-use crate::patch::{apply_hunks, parse_patch};
+use crate::patch::{apply_hunks, apply_hunks_best_effort, parse_patch};
+
+use std::sync::Mutex;
+
+/// Temp dirs registered for cleanup on exit / signal.
+static PATCH_TEMP_DIRS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+/// Remove all registered patch temp dirs. Called from shutdown and signal handlers.
+pub fn cleanup_patch_temp_dirs() {
+    if let Ok(dirs) = PATCH_TEMP_DIRS.lock() {
+        for dir in dirs.iter() {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+}
 
 // ─── Patch file viewing window ─────────────────────────────────────────────
 
@@ -39,6 +53,11 @@ pub(super) fn build_patch_window(
     if let Err(e) = fs::create_dir_all(&tmp_dir) {
         show_patch_error(app, &format!("Cannot create temp directory: {e}"));
         return;
+    }
+
+    // Register for cleanup on shutdown / signal
+    if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
+        dirs.push(tmp_dir.clone());
     }
 
     if base.is_file() {
@@ -96,8 +115,8 @@ fn build_single_file_patch(
     let patched = match apply_hunks(&original, &fp.hunks) {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("Warning: failed to apply patch: {e}");
-            original.clone()
+            eprintln!("Warning: failed to apply patch cleanly: {e}");
+            apply_hunks_best_effort(&original, &fp.hunks)
         }
     };
 
@@ -201,6 +220,8 @@ fn build_multi_file_patch(
     fs::create_dir_all(&left_dir).ok();
     fs::create_dir_all(&right_dir).ok();
 
+    let mut conflict_paths: Vec<String> = Vec::new();
+
     for fp in file_patches {
         let rel_path = &fp.original_path;
         let left_path = left_dir.join(rel_path);
@@ -246,7 +267,8 @@ fn build_multi_file_patch(
                     Ok(c) => c,
                     Err(e) => {
                         eprintln!("Warning: cannot read {}: {e}", orig_path.display());
-                        fs::write(&right_path, "").ok();
+                        let msg = format!("[Cannot read original file]\n\n{e}\n");
+                        fs::write(&right_path, msg).ok();
                         continue;
                     }
                 };
@@ -263,9 +285,9 @@ fn build_multi_file_patch(
                 let patched = match apply_hunks(&original, &fp.hunks) {
                     Ok(p) => p,
                     Err(e) => {
-                        eprintln!("Warning: failed to apply patch to {rel_path}: {e}");
-                        fs::write(&right_path, "").ok();
-                        continue;
+                        eprintln!("Warning: failed to apply patch cleanly to {rel_path}: {e}");
+                        conflict_paths.push(rel_path.clone());
+                        apply_hunks_best_effort(&original, &fp.hunks)
                     }
                 };
 
@@ -274,6 +296,40 @@ fn build_multi_file_patch(
         }
     }
 
+    // Write marker file so the dir scan can color conflicted files red
+    if !conflict_paths.is_empty() {
+        let marker = right_dir.join(".mergers-conflicts");
+        fs::write(&marker, conflict_paths.join("\n")).ok();
+    }
+
+    // Provide sensible labels so the headers show the base dir, not temp paths
+    let patch_labels = if labels.len() >= 2 {
+        labels.to_vec()
+    } else {
+        let base_name = base.file_name().map_or_else(
+            || base.display().to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        );
+        vec![
+            labels.first().cloned().unwrap_or(base_name.clone()),
+            labels
+                .get(1)
+                .cloned()
+                .unwrap_or(format!("{base_name} (patched)")),
+        ]
+    };
+
+    // Tooltip dirs show the original base path (not temp dirs).
+    // Only the left side gets overridden — the right side is generated temp content.
+    let tooltip_dirs = vec![base.display().to_string()];
+
     // Delegate to the existing directory comparison window
-    build_dir_window(app, left_dir, right_dir, labels, Rc::clone(settings));
+    build_dir_window_with_tooltips(
+        app,
+        left_dir,
+        right_dir,
+        &patch_labels,
+        &tooltip_dirs,
+        Rc::clone(settings),
+    );
 }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -1,12 +1,308 @@
 #[allow(clippy::wildcard_imports)]
 use super::*;
+use crate::patch::{apply_hunks, parse_patch};
+
+// ─── Patch file viewing window ─────────────────────────────────────────────
 
 pub(super) fn build_patch_window(
-    _app: &Application,
-    _base: PathBuf,
-    _patch: PathBuf,
-    _labels: &[String],
-    _settings: &Rc<RefCell<Settings>>,
+    app: &Application,
+    base: PathBuf,
+    patch_path: PathBuf,
+    labels: &[String],
+    settings: &Rc<RefCell<Settings>>,
 ) {
-    todo!("patch window implementation")
+    // Read patch file
+    let patch_content = match fs::read_to_string(&patch_path) {
+        Ok(c) => c,
+        Err(e) => {
+            show_patch_error(app, &format!("Cannot read patch file: {e}"));
+            return;
+        }
+    };
+
+    // Parse patch
+    let file_patches = match parse_patch(&patch_content) {
+        Ok(fp) => fp,
+        Err(e) => {
+            show_patch_error(app, &format!("Cannot parse patch: {e}"));
+            return;
+        }
+    };
+
+    if file_patches.is_empty() {
+        show_patch_error(app, "Patch file contains no file entries");
+        return;
+    }
+
+    // Create temp directory with a unique name
+    let tmp_dir = std::env::temp_dir().join(format!("mergers-patch-{}", std::process::id()));
+    if let Err(e) = fs::create_dir_all(&tmp_dir) {
+        show_patch_error(app, &format!("Cannot create temp directory: {e}"));
+        return;
+    }
+
+    if base.is_file() {
+        build_single_file_patch(
+            app,
+            &base,
+            &file_patches,
+            &patch_path,
+            &tmp_dir,
+            labels,
+            settings,
+        );
+    } else if base.is_dir() {
+        build_multi_file_patch(
+            app,
+            &base,
+            &file_patches,
+            &patch_path,
+            &tmp_dir,
+            labels,
+            settings,
+        );
+    } else {
+        show_patch_error(
+            app,
+            &format!("Base path does not exist: {}", base.display()),
+        );
+        let _ = fs::remove_dir_all(&tmp_dir);
+    }
+}
+
+fn show_patch_error(app: &Application, message: &str) {
+    // Create a temporary window to host the error dialog, then show it.
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title("mergers")
+        .default_width(400)
+        .default_height(100)
+        .build();
+    window.present();
+    show_error_dialog(&window, message);
+}
+
+fn build_single_file_patch(
+    app: &Application,
+    base: &Path,
+    file_patches: &[crate::patch::FilePatch],
+    _patch_path: &Path,
+    tmp_dir: &Path,
+    labels: &[String],
+    settings: &Rc<RefCell<Settings>>,
+) {
+    let original = match fs::read_to_string(base) {
+        Ok(c) => c,
+        Err(e) => {
+            show_patch_error(app, &format!("Cannot read base file: {e}"));
+            let _ = fs::remove_dir_all(tmp_dir);
+            return;
+        }
+    };
+
+    let fp = &file_patches[0];
+    let patched = match apply_hunks(&original, &fp.hunks) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Warning: failed to apply patch: {e}");
+            original.clone()
+        }
+    };
+
+    // Write patched content to temp file
+    let base_filename = base.file_name().map_or_else(
+        || "patched".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    );
+    let tmp_path = tmp_dir.join(&base_filename);
+    if let Err(e) = fs::write(&tmp_path, &patched) {
+        show_patch_error(app, &format!("Cannot write temp file: {e}"));
+        let _ = fs::remove_dir_all(tmp_dir);
+        return;
+    }
+
+    // Labels
+    let left_label = labels
+        .first()
+        .cloned()
+        .unwrap_or_else(|| base_filename.clone());
+    let right_label = labels
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| format!("{base_filename} (patched)"));
+    let diff_labels = vec![left_label, right_label];
+
+    let dv = build_diff_view(base, &tmp_path, &diff_labels, settings);
+
+    // Right pane is read-only (patched output)
+    dv.right_save.set_sensitive(false);
+    dv.right_save.set_visible(false);
+
+    // Window title
+    let title = format!("mergers \u{2014} {base_filename} (patch)");
+
+    let AppWindow {
+        window,
+        notebook,
+        open_tabs,
+    } = build_app_window(app, settings, 900, 600, false);
+    window.set_title(Some(&title));
+
+    dv.widget
+        .insert_action_group("diff", Some(&dv.action_group));
+
+    let tab_title = format!("{base_filename} (patch)");
+    notebook.append_page(&dv.widget, Some(&Label::new(Some(&tab_title))));
+
+    // Register tab
+    {
+        let tab_id = NEXT_TAB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        open_tabs.borrow_mut().push(FileTab::Diff {
+            id: tab_id,
+            rel_path: tab_title,
+            widget: dv.widget.clone(),
+            left: PaneInfo {
+                path: dv.left_tab_path.clone(),
+                buf: dv.left_buf.clone(),
+                save: dv.left_save.clone(),
+            },
+            right: PaneInfo {
+                path: dv.right_tab_path.clone(),
+                buf: dv.right_buf.clone(),
+                save: dv.right_save.clone(),
+            },
+        });
+    }
+
+    // Clean up temp dir on destroy
+    let tmp_dir_owned = tmp_dir.to_path_buf();
+    window.connect_destroy(move |_| {
+        let _ = fs::remove_dir_all(&tmp_dir_owned);
+    });
+
+    window.present();
+
+    // Focus the left text view
+    let ltv = dv.left_text_view.clone();
+    gtk4::glib::idle_add_local_once(move || {
+        ltv.grab_focus();
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_multi_file_patch(
+    app: &Application,
+    base: &Path,
+    file_patches: &[crate::patch::FilePatch],
+    patch_path: &Path,
+    tmp_dir: &Path,
+    labels: &[String],
+    settings: &Rc<RefCell<Settings>>,
+) {
+    let patch_filename = patch_path
+        .file_name()
+        .map_or_else(|| "patch".to_string(), |n| n.to_string_lossy().into_owned());
+    let title = format!("mergers \u{2014} {patch_filename}");
+
+    let AppWindow {
+        window,
+        notebook,
+        open_tabs,
+    } = build_app_window(app, settings, 900, 600, false);
+    window.set_title(Some(&title));
+
+    let mut has_tabs = false;
+
+    for fp in file_patches {
+        let rel_path = &fp.original_path;
+        let orig_path = base.join(rel_path);
+
+        let original = match fs::read_to_string(&orig_path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Warning: cannot read {}: {e}", orig_path.display());
+                continue;
+            }
+        };
+
+        let patched = match apply_hunks(&original, &fp.hunks) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("Warning: failed to apply patch to {rel_path}: {e}");
+                original.clone()
+            }
+        };
+
+        // Write patched content — preserve subdirectory structure in temp dir
+        let tmp_path = tmp_dir.join(rel_path);
+        if let Some(parent) = tmp_path.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            eprintln!("Warning: cannot create temp dir for {rel_path}: {e}");
+            continue;
+        }
+        if let Err(e) = fs::write(&tmp_path, &patched) {
+            eprintln!("Warning: cannot write temp file for {rel_path}: {e}");
+            continue;
+        }
+
+        let left_label = labels.first().cloned().unwrap_or_else(|| rel_path.clone());
+        let right_label = labels
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| format!("{rel_path} (patched)"));
+        let diff_labels = vec![left_label, right_label];
+
+        let dv = build_diff_view(&orig_path, &tmp_path, &diff_labels, settings);
+
+        // Right pane is read-only (patched output)
+        dv.right_save.set_sensitive(false);
+        dv.right_save.set_visible(false);
+
+        dv.widget
+            .insert_action_group("diff", Some(&dv.action_group));
+
+        let tab_title = rel_path.clone();
+        notebook.append_page(&dv.widget, Some(&Label::new(Some(&tab_title))));
+
+        // Register tab
+        {
+            let tab_id = NEXT_TAB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            open_tabs.borrow_mut().push(FileTab::Diff {
+                id: tab_id,
+                rel_path: tab_title,
+                widget: dv.widget.clone(),
+                left: PaneInfo {
+                    path: dv.left_tab_path.clone(),
+                    buf: dv.left_buf.clone(),
+                    save: dv.left_save.clone(),
+                },
+                right: PaneInfo {
+                    path: dv.right_tab_path.clone(),
+                    buf: dv.right_buf.clone(),
+                    save: dv.right_save.clone(),
+                },
+            });
+        }
+
+        has_tabs = true;
+    }
+
+    if !has_tabs {
+        show_error_dialog(
+            &window,
+            "No files from the patch could be applied to the base directory",
+        );
+        let _ = fs::remove_dir_all(tmp_dir);
+        window.close();
+        return;
+    }
+
+    // Clean up temp dir on destroy
+    let tmp_dir_owned = tmp_dir.to_path_buf();
+    window.connect_destroy(move |_| {
+        let _ = fs::remove_dir_all(&tmp_dir_owned);
+    });
+
+    window.present();
 }

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -188,6 +188,7 @@ fn build_single_file_patch(
     // Right pane is read-only (patched output)
     dv.right_save.set_sensitive(false);
     dv.right_save.set_visible(false);
+    dv.right_text_view.set_editable(false);
 
     // Window title
     let title = format!("mergers \u{2014} {base_filename} (patch)");

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -9,10 +9,11 @@ static PATCH_TEMP_DIRS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
 /// Remove all registered patch temp dirs. Called from shutdown and signal handlers.
 pub fn cleanup_patch_temp_dirs() {
-    if let Ok(dirs) = PATCH_TEMP_DIRS.lock() {
+    if let Ok(mut dirs) = PATCH_TEMP_DIRS.lock() {
         for dir in dirs.iter() {
             let _ = fs::remove_dir_all(dir);
         }
+        dirs.clear();
     }
 }
 

--- a/src/ui/patch_window.rs
+++ b/src/ui/patch_window.rs
@@ -118,7 +118,33 @@ fn build_single_file_patch(
         }
     };
 
-    let fp = &file_patches[0];
+    // Find the patch entry that matches the base filename, or fall back to
+    // the first entry for single-file patches. This prevents silently applying
+    // an unrelated file's hunks when the patch targets multiple files.
+    let base_name = base
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let fp = if file_patches.len() == 1 {
+        &file_patches[0]
+    } else {
+        let Some(found) = file_patches.iter().find(|fp| {
+            std::path::Path::new(&fp.original_path)
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy() == base_name)
+        }) else {
+            show_patch_error(
+                app,
+                &format!(
+                    "Patch does not contain an entry for '{base_name}'. \
+                     Use directory mode for multi-file patches.",
+                ),
+            );
+            let _ = fs::remove_dir_all(tmp_dir);
+            return;
+        };
+        found
+    };
     let patched = match apply_hunks(&original, &fp.hunks) {
         Ok(p) => p,
         Err(e) => {
@@ -269,6 +295,8 @@ fn build_multi_file_patch(
                     std::os::unix::fs::symlink(&orig_path, &left_path).ok();
                     #[cfg(windows)]
                     fs::copy(&orig_path, &left_path).ok();
+                } else {
+                    eprintln!("Warning: base file not found for deleted entry: {rel_path}");
                 }
             }
             PatchKind::Added => {
@@ -288,8 +316,15 @@ fn build_multi_file_patch(
                     Ok(c) => c,
                     Err(e) => {
                         eprintln!("Warning: cannot read {}: {e}", orig_path.display());
-                        let msg = format!("[Cannot read original file]\n\n{e}\n");
-                        fs::write(&right_path, msg).ok();
+                        // Write error message to both sides so the entry shows as
+                        // Modified (not RightOnly), making the failure obvious.
+                        let msg = format!("[Cannot read original file: {e}]\n");
+                        if let Some(parent) = left_path.parent() {
+                            fs::create_dir_all(parent).ok();
+                        }
+                        fs::write(&left_path, &msg).ok();
+                        fs::write(&right_path, &msg).ok();
+                        conflict_paths.push(rel_path.to_string());
                         continue;
                     }
                 };

--- a/tests/fixtures/dirs.patch
+++ b/tests/fixtures/dirs.patch
@@ -1,0 +1,10 @@
+--- a/different.txt	2024-01-01 00:00:00
++++ b/different.txt	2024-01-01 00:00:00
+@@ -1 +1 @@
+-left version
++right version
+--- a/subdir/nested.txt	2024-01-01 00:00:00
++++ b/subdir/nested.txt	2024-01-01 00:00:00
+@@ -1 +1 @@
+-nested left
++nested right

--- a/tests/fixtures/left_to_right.patch
+++ b/tests/fixtures/left_to_right.patch
@@ -1,0 +1,16 @@
+--- a/left.txt	2024-01-01 00:00:00
++++ b/left.txt	2024-01-01 00:00:00
+@@ -1,10 +1,11 @@
+ line 1
+ line 2
+-line 3
++changed line 3
+ line 4
+ line 5
+-original line 6
++modified line 6
+ line 7
++inserted line 7.5
+ line 8
+ line 9
+ line 10

--- a/tests/ui_integration/test_patch.py
+++ b/tests/ui_integration/test_patch.py
@@ -1,0 +1,40 @@
+"""UI integration tests for patch detection and misc behavior."""
+import os
+import pytest
+
+from conftest import (
+    FIXTURES,
+    find_app,
+    send_keys,
+)
+from dogtail.utils import doDelay
+
+
+def test_diff_extension_detected(app_process, fixture_path):
+    """A .diff file should trigger patch mode."""
+    import shutil
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        diff_file = os.path.join(tmp, "changes.diff")
+        shutil.copy2(fixture_path("left_to_right.patch"), diff_file)
+        proc = app_process(fixture_path("left.txt"), diff_file)
+        app = find_app()
+        doDelay(1)
+        frames = app.findChildren(lambda n: n.roleName == "frame")
+        assert any("patch" in (f.name or "").lower() for f in frames), \
+            f"No patch mode with .diff extension: {[f.name for f in frames]}"
+
+
+def test_ctrl_w_closes_patch_window(app_process, fixture_path):
+    """Ctrl+W should close a patch window cleanly."""
+    proc = app_process(
+        fixture_path("left.txt"),
+        fixture_path("left_to_right.patch"),
+    )
+    app = find_app()
+    doDelay(1)
+    send_keys("ctrl+w", proc.pid)
+    doDelay(1)
+    retcode = proc.poll()
+    assert retcode is not None, "Patch window didn't close on Ctrl+W"

--- a/tests/ui_integration/test_patch.py
+++ b/tests/ui_integration/test_patch.py
@@ -1,6 +1,5 @@
 """UI integration tests for patch detection and misc behavior."""
 import os
-import pytest
 
 from conftest import (
     FIXTURES,

--- a/tests/ui_integration/test_patch_multi.py
+++ b/tests/ui_integration/test_patch_multi.py
@@ -6,9 +6,7 @@ from conftest import (
     FIXTURES,
     _launch_and_wait,
     _kill_proc,
-    find_app,
 )
-from dogtail.utils import doDelay
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui_integration/test_patch_multi.py
+++ b/tests/ui_integration/test_patch_multi.py
@@ -1,0 +1,58 @@
+"""UI integration tests for multi-file patch viewing."""
+import os
+import pytest
+
+from conftest import (
+    FIXTURES,
+    _launch_and_wait,
+    _kill_proc,
+    find_app,
+)
+from dogtail.utils import doDelay
+
+
+@pytest.fixture(scope="module")
+def shared_multi_patch_app():
+    """Multi-file patch: left_dir + dirs.patch."""
+    base = os.path.join(FIXTURES, "left_dir")
+    patch = os.path.join(FIXTURES, "dirs.patch")
+    proc, app = _launch_and_wait(base, patch)
+    yield proc, app
+    _kill_proc(proc)
+
+
+def test_window_opens(shared_multi_patch_app):
+    proc, app = shared_multi_patch_app
+    frames = app.findChildren(lambda n: n.roleName == "frame")
+    assert len(frames) >= 1, "No window frame found"
+
+
+def test_shows_patched_files(shared_multi_patch_app):
+    proc, app = shared_multi_patch_app
+    all_text = []
+    for node in app.findChildren(lambda n: n.showing):
+        try:
+            text = node.text or node.name or ""
+            if text:
+                all_text.append(text)
+        except Exception:
+            pass
+    combined = " ".join(all_text)
+    assert "different.txt" in combined, \
+        f"'different.txt' not found in window content"
+
+
+def test_shows_subdirectory(shared_multi_patch_app):
+    """Directory view should show subdirectories from the patch."""
+    proc, app = shared_multi_patch_app
+    all_text = []
+    for node in app.findChildren(lambda n: n.showing):
+        try:
+            text = node.text or node.name or ""
+            if text:
+                all_text.append(text)
+        except Exception:
+            pass
+    combined = " ".join(all_text)
+    assert "subdir" in combined, \
+        f"'subdir' not found in window content"

--- a/tests/ui_integration/test_patch_single.py
+++ b/tests/ui_integration/test_patch_single.py
@@ -6,12 +6,9 @@ from conftest import (
     FIXTURES,
     _launch_and_wait,
     _kill_proc,
-    find_app,
     find_labels,
-    send_keys,
     wait_for_label,
 )
-from dogtail.utils import doDelay
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui_integration/test_patch_single.py
+++ b/tests/ui_integration/test_patch_single.py
@@ -1,0 +1,83 @@
+"""UI integration tests for single-file patch viewing."""
+import os
+import pytest
+
+from conftest import (
+    FIXTURES,
+    _launch_and_wait,
+    _kill_proc,
+    find_app,
+    find_labels,
+    send_keys,
+    wait_for_label,
+)
+from dogtail.utils import doDelay
+
+
+@pytest.fixture(scope="module")
+def shared_single_patch_app():
+    """Single-file patch: left.txt + left_to_right.patch."""
+    base = os.path.join(FIXTURES, "left.txt")
+    patch = os.path.join(FIXTURES, "left_to_right.patch")
+    proc, app = _launch_and_wait(base, patch)
+    yield proc, app
+    _kill_proc(proc)
+
+
+def test_window_title_contains_patch(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    frames = app.findChildren(lambda n: n.roleName == "frame")
+    assert any("patch" in (f.name or "").lower() for f in frames), \
+        f"No frame with 'patch' in title: {[f.name for f in frames]}"
+
+
+def test_window_title_contains_filename(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    frames = app.findChildren(lambda n: n.roleName == "frame")
+    assert any("left.txt" in (f.name or "") for f in frames), \
+        f"No frame with 'left.txt' in title: {[f.name for f in frames]}"
+
+
+def test_has_two_text_panes(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    texts = app.findChildren(lambda n: n.roleName == "text")
+    assert len(texts) >= 2, f"Expected >=2 text panes, got {len(texts)}"
+
+
+def test_left_pane_contains_original(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    texts = app.findChildren(lambda n: n.roleName == "text")
+    left_text = texts[0].text if texts else ""
+    assert "original line 6" in left_text, \
+        f"Left pane missing original content: {left_text[:200]}"
+
+
+def test_right_pane_contains_patched(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    texts = app.findChildren(lambda n: n.roleName == "text")
+    right_text = texts[1].text if len(texts) > 1 else ""
+    assert "modified line 6" in right_text, \
+        f"Right pane missing patched content: {right_text[:200]}"
+
+
+def test_right_pane_has_insertion(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    texts = app.findChildren(lambda n: n.roleName == "text")
+    right_text = texts[1].text if len(texts) > 1 else ""
+    assert "inserted line 7.5" in right_text, \
+        f"Right pane missing inserted line: {right_text[:200]}"
+
+
+def test_chunk_label_shows_changes(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    result = wait_for_label(app, lambda t: "change" in t.lower())
+    assert result is not None, \
+        f"No label with 'change' found: {find_labels(app)}"
+
+
+def test_tab_label_contains_patch(shared_single_patch_app):
+    proc, app = shared_single_patch_app
+    tabs = app.findChildren(lambda n: n.roleName == "page tab")
+    tab_names = [t.name or "" for t in tabs]
+    assert any("patch" in name.lower() for name in tab_names), \
+        f"No tab with 'patch' in label: {tab_names}"


### PR DESCRIPTION
## Summary

- Parse unified and context diff formats into structured `FilePatch` / `Hunk` types
- Auto-detect patch files by extension (`.patch`, `.diff`) or content signatures
- **Single-file patch**: opens a two-pane diff view (original vs patched), right pane read-only
- **Multi-file patch**: creates a directory comparison with symlinked originals and patched copies
- Apply hunks with strict validation (`apply_hunks`) or best-effort with conflict markers (`apply_hunks_best_effort`)
- "Apply all non-conflicting" button applies clean hunks right-to-left, skipping conflicts
- Path sanitization strips leading `/`/`\` to make paths relative (like `git apply`), rejects `..` traversal and Windows drive letters
- Conflict coloring for failed hunks in multi-file patch view
- Temp directory cleanup on window destroy, process shutdown, and SIGINT/SIGTERM
- Temp directories created with 0o700 permissions (owner-only)

## Tests

- 26 unit tests for patch parsing, application, and conflict detection
- Round-trip parse+apply integration tests
- 13 UI integration tests:
  - Single-file patch (8): window title, pane content, chunk label, tab label
  - Multi-file patch (3): window opens, shows files and subdirectories
  - Detection (2): `.diff` extension auto-detected, Ctrl+W closes cleanly

## Other changes

- Fix `criterion::black_box` deprecation (use `std::hint::black_box`)
- Fix clippy `format_push_string` warnings in patch tests

## Test plan

- [x] `cargo test --all-targets` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings -W clippy::pedantic` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)